### PR TITLE
Ajout d'états de chargement pour les catégories

### DIFF
--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -33,6 +33,15 @@ class _CategoryScreenState extends State<CategoryScreen> {
       body: FutureBuilder<List<FamilleInfractions>>(
         future: _families,
         builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(
+              child: Text('Erreur lors du chargement des catégories'),
+            );
+          }
+
           final families = snapshot.data ?? <FamilleInfractions>[];
           return ListView.builder(
             itemCount: families.length,


### PR DESCRIPTION
## Résumé
- ajoute la gestion des états `waiting` et `hasError` dans `CategoryScreen`

## Tests
- `flutter test` *(échoue : `flutter` absent)*

------
https://chatgpt.com/codex/tasks/task_e_686daafc3d10832d885b43b62e048142