### PR TITLE
Fix JSON parsing of infraction tentative

### DIFF
--- a/lib/models/infraction.dart
+++ b/lib/models/infraction.dart
@@ -41,14 +41,15 @@ class Penalites {
 }
 
 class TentativeInfraction {
-  final bool? punissable;
+  /// Peut être `true`, `false` ou une chaîne descriptive (ex: "Non applicable")
+  final String? punissable;
   final String? precision;
   final InfractionArticle? article;
 
   TentativeInfraction({this.punissable, this.precision, this.article});
 
   factory TentativeInfraction.fromJson(Map<String, dynamic> json) => TentativeInfraction(
-        punissable: json['punissable'],
+        punissable: json['punissable']?.toString(),
         precision: json['precision'],
         article: json['article'] != null ? InfractionArticle.fromJson(json['article']) : null,
       );


### PR DESCRIPTION
## Summary
- handle `punissable` values that are strings when loading infractions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daebf7c80832d91e114b571202901