### PR TITLE
Amélioration du chargement JSON

### DIFF
--- a/assets/data/loader_test.json
+++ b/assets/data/loader_test.json
@@ -1,0 +1,6 @@
+{
+  // Comment en début de fichier
+  "message": "Bonjour // ceci n'est pas un commentaire",
+  /* Commentaire multi-lignes */
+  "description": "Un texte avec /* des caractères */ dans la valeur"
+}

--- a/lib/utils/json_loader.dart
+++ b/lib/utils/json_loader.dart
@@ -5,13 +5,57 @@ import 'package:flutter/services.dart' show rootBundle;
 /// de renvoyer la chaîne.
 Future<String> loadJsonWithComments(String path) async {
   final data = await rootBundle.loadString(path);
-  final withoutBlock = data.replaceAll(
-    RegExp(r'/\*.*?\*/', dotAll: true),
-    '',
-  );
-  final withoutLine = withoutBlock.replaceAll(
-    RegExp(r'^\s*//.*\$', multiLine: true),
-    '',
-  );
-  return withoutLine;
+  final buffer = StringBuffer();
+  var inString = false;
+  var escaping = false;
+
+  for (var i = 0; i < data.length; i++) {
+    final char = data[i];
+
+    if (inString) {
+      buffer.write(char);
+      if (escaping) {
+        escaping = false;
+      } else if (char == '\\') {
+        escaping = true;
+      } else if (char == '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char == '"') {
+      inString = true;
+      buffer.write(char);
+      continue;
+    }
+
+    if (char == '/' && i + 1 < data.length) {
+      final next = data[i + 1];
+      // Skip line comments
+      if (next == '/') {
+        i += 1;
+        while (i + 1 < data.length && data[i + 1] != '\n') {
+          i++;
+        }
+        continue;
+      }
+      // Skip block comments
+      if (next == '*') {
+        i += 1;
+        while (i + 1 < data.length) {
+          if (data[i + 1] == '*' && i + 2 < data.length && data[i + 2] == '/') {
+            i += 2;
+            break;
+          }
+          i++;
+        }
+        continue;
+      }
+    }
+
+    buffer.write(char);
+  }
+
+  return buffer.toString();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ flutter:
   assets:
     - assets/data/fiches.json
     - assets/data/cadres.json
+    - assets/data/loader_test.json
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/test/json_loader_test.dart
+++ b/test/json_loader_test.dart
@@ -1,0 +1,15 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poljud/utils/json_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('parse json with comments and comment-like strings', () async {
+    final jsonStr = await loadJsonWithComments('assets/data/loader_test.json');
+    final data = json.decode(jsonStr) as Map<String, dynamic>;
+    expect(data['message'], "Bonjour // ceci n'est pas un commentaire");
+    expect(data['description'], "Un texte avec /* des caractères */ dans la valeur");
+  });
+}


### PR DESCRIPTION
## Résumé
- prise en compte des commentaires sans impacter le contenu des chaînes
- ajout d’un fichier de test contenant `//` et `/*`
- ajout d’un test unitaire pour valider le chargement
- déclaration de cette ressource dans `pubspec.yaml`

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68718ee74898832d813a0fd57caa3c64