### PR TITLE
Supprimer le test réseau inutile

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,10 @@
-import 'dart:io';
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'utils/theme.dart';
 
-void main() async {
+void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  await _testLocalNetworkAccess();
   runApp(const OPJFichesApp());
-}
-
-Future<void> _testLocalNetworkAccess() async {
-  try {
-    final socket = await Socket.connect('192.168.1.1', 80, timeout: Duration(seconds: 2));
-    socket.destroy();
-  } catch (_) {
-    // Erreur ignorée intentionnellement
-  }
 }
 
 class OPJFichesApp extends StatelessWidget {


### PR DESCRIPTION
## Résumé
- retrait de la fonction `_testLocalNetworkAccess` et de son appel dans `main.dart`
- simplification du `main` qui n'est plus asynchrone

## Tests
- `flutter` et `dart` non disponibles dans l'environnement : impossible d'exécuter les tests

------
https://chatgpt.com/codex/tasks/task_e_68718ef2d93c832d99f2f66c22a542c3