### PR TITLE
Ajout d'un écran de thèmes

### DIFF
--- a/lib/models/theme_category.dart
+++ b/lib/models/theme_category.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class ThemeCategory {
+  final String id;
+  final String title;
+  final IconData icon;
+  final Color color;
+  final List<String> keywords;
+
+  const ThemeCategory({
+    required this.id,
+    required this.title,
+    required this.icon,
+    required this.color,
+    required this.keywords,
+  });
+}
+
+const List<ThemeCategory> kThemeCategories = [
+  ThemeCategory(
+    id: 'personnes',
+    title: 'Atteintes aux personnes',
+    icon: Icons.person,
+    color: Colors.red,
+    keywords: [
+      'personne',
+      'mineur',
+      'vie',
+      'violence',
+      'int\u00e9grit\u00e9',
+      'dignit\u00e9',
+      'danger',
+    ],
+  ),
+  ThemeCategory(
+    id: 'administration',
+    title: "Administration publique",
+    icon: Icons.account_balance,
+    color: Colors.blue,
+    keywords: [
+      'administration',
+      'autorite',
+      'justice',
+      'public',
+      'probite',
+      'confiance',
+    ],
+  ),
+  ThemeCategory(
+    id: 'armes',
+    title: 'Armes',
+    icon: Icons.security,
+    color: Colors.brown,
+    keywords: ['arme', 'explosif', 'poudre'],
+  ),
+  ThemeCategory(
+    id: 'stups',
+    title: 'Stup\u00e9fiants',
+    icon: Icons.healing,
+    color: Colors.purple,
+    keywords: ['stup\u00e9fiant'],
+  ),
+  ThemeCategory(
+    id: 'routiere',
+    title: 'Circulation routi\u00e8re',
+    icon: Icons.directions_car,
+    color: Colors.green,
+    keywords: ['routi', 'circulation'],
+  ),
+];

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'category_screen.dart';
+import 'theme_screen.dart';
 import 'favorites_screen.dart';
 import 'cadre_list_screen.dart';
 
@@ -38,7 +38,7 @@ class HomeScreen extends StatelessWidget {
                     PageRouteBuilder(
                       pageBuilder: (_, animation, __) => FadeTransition(
                         opacity: animation,
-                        child: const CategoryScreen(),
+                        child: const ThemeScreen(),
                       ),
                     ),
                   );

--- a/lib/screens/theme_screen.dart
+++ b/lib/screens/theme_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../models/theme_category.dart';
+import 'category_screen.dart';
+
+class ThemeScreen extends StatelessWidget {
+  const ThemeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Th\u00e8mes')),
+      body: GridView.builder(
+        padding: const EdgeInsets.all(16),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+          childAspectRatio: 1.2,
+        ),
+        itemCount: kThemeCategories.length,
+        itemBuilder: (context, index) {
+          final cat = kThemeCategories[index];
+          return InkWell(
+            borderRadius: BorderRadius.circular(16),
+            onTap: () {
+              Navigator.of(context).push(
+                PageRouteBuilder(
+                  pageBuilder: (_, animation, __) => FadeTransition(
+                    opacity: animation,
+                    child: CategoryScreen(category: cat),
+                  ),
+                ),
+              );
+            },
+            child: Container(
+              decoration: BoxDecoration(
+                color: cat.color.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(cat.icon, color: cat.color, size: 40),
+                  const SizedBox(height: 8),
+                  Text(
+                    cat.title,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- création d'un modèle `ThemeCategory` décrivant les thèmes
- nouvel écran `ThemeScreen` listant 5 thèmes illustrés
- filtrage des familles dans `CategoryScreen` selon le thème choisi
- mise à jour de `HomeScreen` pour ouvrir `ThemeScreen`

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6872263e4690832dac8213e43b8478c8