### PR TITLE
Ajout d'un écran de recherche global

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'category_screen.dart';
 import 'favorites_screen.dart';
 import 'cadre_list_screen.dart';
+import 'search_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -39,6 +40,26 @@ class HomeScreen extends StatelessWidget {
                       pageBuilder: (_, animation, __) => FadeTransition(
                         opacity: animation,
                         child: const CategoryScreen(),
+                      ),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.search),
+                label: const Text('Recherche'),
+                style: ElevatedButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  textStyle: const TextStyle(fontSize: 18),
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    PageRouteBuilder(
+                      pageBuilder: (_, animation, __) => FadeTransition(
+                        opacity: animation,
+                        child: const SearchScreen(),
                       ),
                     ),
                   );

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../models/infraction.dart';
+import '../utils/json_loader.dart';
+import '../widgets/infraction_card.dart';
+import '../widgets/search_bar.dart';
+import 'infraction_detail_screen.dart';
+
+class SearchScreen extends StatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  List<Infraction> _allInfractions = [];
+  List<Infraction> _filteredInfractions = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInfractions();
+  }
+
+  Future<void> _loadInfractions() async {
+    final data = await loadJsonWithComments('assets/data/fiches.json');
+    final List<dynamic> rawFamilies = json.decode(data);
+    final families = rawFamilies
+        .map((e) => FamilleInfractions.fromJson(e as Map<String, dynamic>))
+        .toList();
+    _allInfractions = families.expand((f) => f.infractions).toList();
+    setState(() {
+      _filteredInfractions = _allInfractions;
+      _isLoading = false;
+    });
+  }
+
+  void _onSearch(String query) {
+    final lower = query.toLowerCase();
+    setState(() {
+      _filteredInfractions = _allInfractions
+          .where((inf) => (inf.type ?? '').toLowerCase().contains(lower) ||
+              (inf.definition ?? '').toLowerCase().contains(lower))
+          .toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Recherche')),
+      body: Column(
+        children: [
+          CustomSearchBar(
+            hintText: 'Rechercher une infraction…',
+            onChanged: _onSearch,
+          ),
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ListView.builder(
+                      key: const ValueKey('searchList'),
+                      itemCount: _filteredInfractions.length,
+                      itemBuilder: (context, index) {
+                        final infraction = _filteredInfractions[index];
+                        return InfractionCard(
+                          infraction: infraction,
+                          onTap: () {
+                            Navigator.of(context).push(
+                              PageRouteBuilder(
+                                pageBuilder: (_, animation, __) => FadeTransition(
+                                  opacity: animation,
+                                  child: InfractionDetailScreen(
+                                      infraction: infraction),
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- ajoute `SearchScreen` pour filtrer toutes les infractions
- intègre ce nouvel écran depuis `HomeScreen` avec un bouton *Recherche*

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68722642a6cc832da2a2c183e703dce3