### PR TITLE
Add family consistency test

### DIFF
--- a/test/category_families_test.dart
+++ b/test/category_families_test.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poljud/models/category.dart';
+import 'package:poljud/utils/json_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('chaque famille du fichier fiches.json est dans categoryFamilies', () async {
+    final jsonStr = await loadJsonWithComments('assets/data/fiches.json');
+    final List<dynamic> fiches = json.decode(jsonStr) as List<dynamic>;
+    final Set<String> familiesFromFile =
+        fiches.map((e) => e['famille'] as String).toSet();
+
+    final Set<String> familiesFromCategories =
+        categoryFamilies.values.expand((e) => e).toSet();
+
+    expect(familiesFromCategories.containsAll(familiesFromFile), isTrue,
+        reason: 'Des familles sont manquantes dans categoryFamilies');
+  });
+}


### PR DESCRIPTION
## Summary
- add a unit test ensuring every `famille` in `fiches.json` appears in `categoryFamilies`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722ca7ff38832d9bc9bc141ea960e1