### PR TITLE
Ajout écrans et modèles pour cadres d'enquête

### DIFF
--- a/lib/models/cadre.dart
+++ b/lib/models/cadre.dart
@@ -1,20 +1,65 @@
-class Cadre {
-  final String id;
+class CadreLegal {
   final String titre;
-  final List<String> references;
-  final String description;
+  final String articles;
+  final List<String> commentaires;
 
-  Cadre({
-    required this.id,
-    required this.titre,
-    required this.references,
-    required this.description,
-  });
+  CadreLegal({required this.titre, required this.articles, required this.commentaires});
+
+  factory CadreLegal.fromJson(Map<String, dynamic> json) {
+    final comments = <String>[];
+    for (var i = 1; i <= 6; i++) {
+      final key = 'commentaire$i';
+      final value = json[key];
+      if (value != null && value.toString().trim().isNotEmpty) {
+        comments.add(value.toString());
+      }
+    }
+    return CadreLegal(
+      titre: json['titre'] ?? '',
+      articles: json['articles'] ?? '',
+      commentaires: comments,
+    );
+  }
+}
+
+class ActeCadre {
+  final String acte;
+  final String articles;
+  final List<String> commentaires;
+
+  ActeCadre({required this.acte, required this.articles, required this.commentaires});
+
+  factory ActeCadre.fromJson(Map<String, dynamic> json) {
+    final comments = <String>[];
+    for (var i = 1; i <= 6; i++) {
+      final key = 'commentaire$i';
+      final value = json[key];
+      if (value != null && value.toString().trim().isNotEmpty) {
+        comments.add(value.toString());
+      }
+    }
+    return ActeCadre(
+      acte: json['acte'] ?? '',
+      articles: json['articles'] ?? '',
+      commentaires: comments,
+    );
+  }
+}
+
+class Cadre {
+  final String cadre;
+  final CadreLegal cadreLegal;
+  final List<ActeCadre> actes;
+
+  Cadre({required this.cadre, required this.cadreLegal, required this.actes});
 
   factory Cadre.fromJson(Map<String, dynamic> json) => Cadre(
-        id: json['id'],
-        titre: json['titre'],
-        references: List<String>.from(json['references']),
-        description: json['description'],
+        cadre: json['cadre'] ?? '',
+        cadreLegal: CadreLegal.fromJson(
+            (json['cadre legal'] as Map?)?.cast<String, dynamic>() ?? {}),
+        actes: (json['actes'] as List? ?? [])
+            .whereType<Map>()
+            .map((e) => ActeCadre.fromJson(e.cast<String, dynamic>()))
+            .toList(),
       );
 }

--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../models/cadre.dart';
+
+class CadreDetailScreen extends StatelessWidget {
+  final Cadre cadre;
+  const CadreDetailScreen({super.key, required this.cadre});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(cadre.cadre)),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(cadre.cadreLegal.titre,
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            if (cadre.cadreLegal.articles.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(cadre.cadreLegal.articles),
+              ),
+            ...cadre.cadreLegal.commentaires
+                .map((c) => Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(c),
+                    ))
+                .toList(),
+            const SizedBox(height: 12),
+            if (cadre.actes.isNotEmpty)
+              const Text('Actes',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+            ...cadre.actes.map(
+              (a) => Padding(
+                padding: const EdgeInsets.only(top: 8, bottom: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(a.acte,
+                        style: const TextStyle(fontWeight: FontWeight.w600)),
+                    if (a.articles.isNotEmpty) Text(a.articles),
+                    ...a.commentaires
+                        .map((c) => Text('• $c'))
+                        .toList(),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/cadres_parsing_test.dart
+++ b/test/cadres_parsing_test.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poljud/models/cadre.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('chargement des cadres depuis cadres.json', () async {
+    final data = await rootBundle.loadString('assets/data/cadres.json');
+    final List<dynamic> list = json.decode(data) as List<dynamic>;
+    expect(() => list.map((e) => Cadre.fromJson(e as Map<String, dynamic>)).toList(), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Résumé
- ajoute un modèle complet `Cadre` avec `CadreLegal` et `ActeCadre`
- lit les clés "cadre legal" et "actes" dans `Cadre.fromJson`
- nouvelle page `CadreDetailScreen` présentant le cadre légal et les actes
- mise à jour de `CadreListScreen` avec recherche et navigation vers le détail
- test de conversion du fichier `cadres.json`

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6872df923404832db978fbe64a55d5b3