### PR TITLE
Retrait de la barre de recherche

### DIFF
--- a/lib/screens/cadre_list_screen.dart
+++ b/lib/screens/cadre_list_screen.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/cadre.dart';
-import '../widgets/search_bar.dart';
 import 'cadre_detail_screen.dart';
 
 class CadreListScreen extends StatefulWidget {
@@ -14,7 +13,6 @@ class CadreListScreen extends StatefulWidget {
 
 class _CadreListScreenState extends State<CadreListScreen> {
   List<Cadre> cadres = [];
-  List<Cadre> filteredCadres = [];
   bool isLoading = true;
 
   @override
@@ -27,19 +25,11 @@ class _CadreListScreenState extends State<CadreListScreen> {
     final data = await rootBundle.loadString('assets/data/cadres.json');
     final List<dynamic> list = json.decode(data);
     cadres = list.map((e) => Cadre.fromJson(e as Map<String, dynamic>)).toList();
-    filteredCadres = cadres;
     setState(() {
       isLoading = false;
     });
   }
 
-  void onSearch(String query) {
-    setState(() {
-      filteredCadres = cadres
-          .where((c) => c.cadre.toLowerCase().contains(query.toLowerCase()))
-          .toList();
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -47,10 +37,6 @@ class _CadreListScreenState extends State<CadreListScreen> {
       appBar: AppBar(title: const Text("Cadres d'enquête")),
       body: Column(
         children: [
-          CustomSearchBar(
-            hintText: 'Rechercher un cadre…',
-            onChanged: onSearch,
-          ),
           Expanded(
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 300),
@@ -58,9 +44,9 @@ class _CadreListScreenState extends State<CadreListScreen> {
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.builder(
                       key: const ValueKey('list'),
-                      itemCount: filteredCadres.length,
+                      itemCount: cadres.length,
                       itemBuilder: (context, index) {
-                        final cadre = filteredCadres[index];
+                        final cadre = cadres[index];
                         return Card(
                           margin: const EdgeInsets.symmetric(
                               vertical: 8, horizontal: 16),


### PR DESCRIPTION
## Résumé
- suppression de l'import et de la logique de recherche dans `CadreListScreen`
- affichage direct de la liste des cadres

## Tests
- `flutter analyze` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2a23850832dbe23747cc41d7f8b