### PR TITLE
Sort infractions alphabetically in search menu

### DIFF
--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -30,7 +30,12 @@ class _SearchScreenState extends State<SearchScreen> {
     final families = rawFamilies
         .map((e) => FamilleInfractions.fromJson(e as Map<String, dynamic>))
         .toList();
-    _allInfractions = families.expand((f) => f.infractions).toList();
+    _allInfractions = families.expand((f) => f.infractions).toList()
+      ..sort(
+        (a, b) => (a.type ?? '').toLowerCase().compareTo(
+              (b.type ?? '').toLowerCase(),
+            ),
+      );
     setState(() {
       _filteredInfractions = _allInfractions;
       _isLoading = false;


### PR DESCRIPTION
## Summary
- sort infractions by `type` when loading them for the search screen

## Testing
- `dart format lib/screens/search_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/search_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e27e7374832dac4a32877a968faa