### PR TITLE
Ajout du logo à l'accueil

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -19,15 +19,26 @@ class HomeScreen extends StatelessWidget {
             end: Alignment.bottomRight,
           ),
         ),
-        child: Center(
+        child: SafeArea(
           child: Column(
-            mainAxisSize: MainAxisSize.min,
             children: [
-              FractionallySizedBox(
-                widthFactor: 0.85,
-                child: _ModernGradientButton(
-                  icon: Icons.book,
-                  label: 'Infractions par thèmes',
+              Padding(
+                padding: const EdgeInsets.only(top: 16, bottom: 32),
+                child: Image.asset(
+                  'assets/images/logocreme.png',
+                  width: 160,
+                ),
+              ),
+              Expanded(
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: _ModernGradientButton(
+                          icon: Icons.book,
+                          label: 'Infractions par thèmes',
                   onPressed: () {
                     Navigator.of(context).push(
                       PageRouteBuilder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ flutter:
     - assets/data/fiches.json
     - assets/data/cadres.json
     - assets/data/loader_test.json
+    - assets/images/
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
## Summary
- ajout du dossier `assets/images/` dans les assets Flutter
- ajout de `logocreme.png` en haut de la page d'accueil avec `SafeArea`

## Testing
- `flutter test` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68737bdfdfc4832dbd65cc5b997aeea2