### PR TITLE
Affichage des catégories sous forme d'images

### DIFF
--- a/lib/screens/theme_screen.dart
+++ b/lib/screens/theme_screen.dart
@@ -2,6 +2,13 @@ import 'package:flutter/material.dart';
 import '../models/theme_category.dart';
 import 'category_screen.dart';
 
+const _categoryImages = {
+  'personnes': 'assets/images/infractions_personnes.png',
+  'biens': 'assets/images/infractions_biens.png',
+  'nation': 'assets/images/infractions_nation.png',
+  'autres': 'assets/images/infractions_autres.png',
+};
+
 class ThemeScreen extends StatelessWidget {
   const ThemeScreen({super.key});
 
@@ -9,17 +16,13 @@ class ThemeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Th\u00e8mes')),
-      body: GridView.builder(
+      body: ListView.separated(
         padding: const EdgeInsets.all(16),
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          crossAxisSpacing: 16,
-          mainAxisSpacing: 16,
-          childAspectRatio: 1.2,
-        ),
         itemCount: kThemeCategories.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 16),
         itemBuilder: (context, index) {
           final cat = kThemeCategories[index];
+          final image = _categoryImages[cat.id];
           return InkWell(
             borderRadius: BorderRadius.circular(16),
             onTap: () {
@@ -32,25 +35,14 @@ class ThemeScreen extends StatelessWidget {
                 ),
               );
             },
-            child: Container(
-              decoration: BoxDecoration(
-                color: cat.color.withOpacity(0.2),
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(cat.icon, color: cat.color, size: 40),
-                  const SizedBox(height: 8),
-                  Text(
-                    cat.title,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: AspectRatio(
+                aspectRatio: 3 / 2,
+                child: Image.asset(
+                  image ?? '',
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
           );


### PR DESCRIPTION
## Summary
- remplace la grille de `ThemeScreen` par une liste verticale d'images cliquables

## Testing
- `dart test` *(échoue : commande introuvable)*
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68737dd903a4832d8e5457a5a4f22857