### PR TITLE
Bold text when tile expanded

### DIFF
--- a/lib/widgets/gradient_expansion_tile.dart
+++ b/lib/widgets/gradient_expansion_tile.dart
@@ -51,7 +51,14 @@ class _GradientExpansionTileState extends State<GradientExpansionTile> {
           ),
           childrenPadding:
               const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-          children: widget.children,
+          children: _expanded
+              ? widget.children
+                  .map((child) => DefaultTextStyle.merge(
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                        child: child,
+                      ))
+                  .toList()
+              : widget.children,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- wrap children of `GradientExpansionTile` in a bold `DefaultTextStyle` when expanded

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687380744800832da10ff0c2b006dac7