### PR TITLE
Ajout config flutter_launcher_icons

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  flutter_launcher_icons: ^0.13.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -92,3 +93,8 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
+
+flutter_icons:
+  android: true
+  ios: true
+  image_path: "assets/images/logo.png"


### PR DESCRIPTION
## Summary
- ajoute la dépendance `flutter_launcher_icons` dans `pubspec.yaml`
- ajoute la section `flutter_icons`

## Testing
- `flutter pub get` *(échoue : commande introuvable)*
- `flutter pub run flutter_launcher_icons:main` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68739d9ba680832d98263b7264941506