### PR TITLE
Affichage oui/non pour tentative

### DIFF
--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -160,7 +160,9 @@ class InfractionDetailScreen extends StatelessWidget {
                 title: const Text('Tentative'),
                 children: [
                   if (infraction.tentative!.punissable != null)
-                    Text('Punissable : ${infraction.tentative!.punissable}'),
+                    Text(
+                      'Punissable : ${_formatPunissable(infraction.tentative!.punissable!)}',
+                    ),
                   if (infraction.tentative!.precision != null)
                     Text(infraction.tentative!.precision!),
                   if (infraction.tentative!.article != null)
@@ -284,6 +286,13 @@ class InfractionDetailScreen extends StatelessWidget {
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
     }
+  }
+
+  String _formatPunissable(String value) {
+    final lower = value.toLowerCase();
+    if (lower == 'true') return 'Oui';
+    if (lower == 'false') return 'Non';
+    return value;
   }
 
   String _formatArticle(InfractionArticle article) {


### PR DESCRIPTION
## Summary
- ne plus afficher les valeurs booléennes `true`/`false` dans l'écran de détail
- ajout d'une méthode de formatage du champ `punissable`

## Testing
- `flutter test` *(échoue : `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_6873a17ab438832d81e356513e3cc897