### PR TITLE
Utilise le dégradé de HomeScreen

### DIFF
--- a/lib/widgets/gradient_expansion_tile.dart
+++ b/lib/widgets/gradient_expansion_tile.dart
@@ -28,9 +28,11 @@ class _GradientExpansionTileState extends State<GradientExpansionTile> {
   @override
   Widget build(BuildContext context) {
     final decoration = _expanded
-        ? BoxDecoration(
+        ? const BoxDecoration(
             gradient: LinearGradient(
-              colors: [Colors.green.shade200, Colors.green.shade400],
+              colors: [Color(0xFF001F4D), Color(0xFF122046)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomRight,
             ),
           )
         : null;


### PR DESCRIPTION
## Résumé
- remplace le dégradé vert par celui utilisé dans `HomeScreen`
- maintient l'application du décor uniquement quand le tile est ouvert

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6873a5558a4c832d9b7b438a5fa4ecda