### PR TITLE
Ajout du tri alphabétique des familles

### DIFF
--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -48,6 +48,11 @@ class _CategoryScreenState extends State<CategoryScreen> {
             })
             .toList();
       }
+      families.sort(
+        (a, b) => (a.famille ?? '').toLowerCase().compareTo(
+          (b.famille ?? '').toLowerCase(),
+        ),
+      );
       return families;
     } catch (e, stack) {
       debugPrint('Erreur lors du chargement des familles: $e');


### PR DESCRIPTION
## Summary
- trie les familles d'infractions par nom avant de les afficher

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6873a7e0e8c8832d8053a2293e7a86aa