### PR TITLE
Ajout du widget AdaptiveAppBarTitle

### DIFF
--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/cadre.dart';
 import '../widgets/gradient_expansion_tile.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class CadreDetailScreen extends StatelessWidget {
   final Cadre cadre;
@@ -14,10 +15,7 @@ class CadreDetailScreen extends StatelessWidget {
           tag: 'cadreTitle-${cadre.cadre}',
           child: Material(
             color: Colors.transparent,
-            child: Text(
-              cadre.cadre,
-              style: TextStyle(color: Colors.white),
-            ),
+            child: AdaptiveAppBarTitle(cadre.cadre),
           ),
         ),
       ),

--- a/lib/screens/cadre_list_screen.dart
+++ b/lib/screens/cadre_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/cadre.dart';
 import 'cadre_detail_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class CadreListScreen extends StatefulWidget {
   const CadreListScreen({super.key});
@@ -34,7 +35,9 @@ class _CadreListScreenState extends State<CadreListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Cadres d'enquête")),
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle("Cadres d'enquête"),
+      ),
       body: Column(
         children: [
           Expanded(

--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -4,6 +4,7 @@ import '../utils/json_loader.dart';
 import '../models/infraction.dart';
 import '../models/theme_category.dart';
 import 'fiche_list_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class CategoryScreen extends StatefulWidget {
   final ThemeCategory? category;
@@ -65,7 +66,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.category?.title ?? 'Catégories'),
+        title: AdaptiveAppBarTitle(widget.category?.title ?? 'Catégories'),
       ),
       body: FutureBuilder<List<FamilleInfractions>>(
         future: _families,

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -5,6 +5,7 @@ import '../models/infraction.dart';
 import '../widgets/infraction_card.dart';
 import '../utils/favorites_manager.dart';
 import 'infraction_detail_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class FavoritesScreen extends StatefulWidget {
   const FavoritesScreen({super.key});
@@ -40,7 +41,9 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Favoris')),
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Favoris'),
+      ),
       body: AnimatedSwitcher(
         duration: const Duration(milliseconds: 300),
         child: isLoading

--- a/lib/screens/fiche_list_screen.dart
+++ b/lib/screens/fiche_list_screen.dart
@@ -3,6 +3,7 @@ import '../models/infraction.dart';
 import '../widgets/infraction_card.dart';
 import '../widgets/search_bar.dart';
 import 'infraction_detail_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class FicheListScreen extends StatefulWidget {
   final FamilleInfractions famille;
@@ -47,7 +48,7 @@ class _FicheListScreenState extends State<FicheListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.famille.famille ?? 'Infractions'),
+        title: AdaptiveAppBarTitle(widget.famille.famille ?? 'Infractions'),
       ),
       body: Column(
         children: [

--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../models/infraction.dart';
 import '../widgets/gradient_expansion_tile.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class InfractionDetailScreen extends StatelessWidget {
   final Infraction infraction;
@@ -10,7 +11,9 @@ class InfractionDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(infraction.type ?? 'Infraction')),
+      appBar: AppBar(
+        title: AdaptiveAppBarTitle(infraction.type ?? 'Infraction'),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -5,6 +5,7 @@ import '../utils/json_loader.dart';
 import '../widgets/infraction_card.dart';
 import '../widgets/search_bar.dart';
 import 'infraction_detail_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -55,7 +56,9 @@ class _SearchScreenState extends State<SearchScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Recherche')),
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Recherche'),
+      ),
       body: Column(
         children: [
           CustomSearchBar(

--- a/lib/screens/theme_screen.dart
+++ b/lib/screens/theme_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/theme_category.dart';
 import 'category_screen.dart';
+import '../widgets/adaptive_appbar_title.dart';
 
 const _categoryImages = {
   'personnes': 'assets/images/infractions_personnes.png',
@@ -15,7 +16,9 @@ class ThemeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Th\u00e8mes')),
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Th\u00e8mes'),
+      ),
       body: ListView.separated(
         padding: const EdgeInsets.all(16),
         itemCount: kThemeCategories.length,

--- a/lib/widgets/adaptive_appbar_title.dart
+++ b/lib/widgets/adaptive_appbar_title.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class AdaptiveAppBarTitle extends StatelessWidget {
+  final String text;
+  final int maxLines;
+  const AdaptiveAppBarTitle(this.text, {super.key, this.maxLines = 2});
+
+  @override
+  Widget build(BuildContext context) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      child: Text(text, maxLines: maxLines, textAlign: TextAlign.center),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- création du widget `AdaptiveAppBarTitle`
- utilisation de ce widget dans tous les écrans utilisant `AppBar`
- ajout des imports nécessaires

## Tests
- `flutter analyze` *(échoue : commande introuvable)*
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6873de153934832d9909394fe419fe91