### PR TITLE
Améliore affichage du titre dans l'AppBar

### DIFF
--- a/lib/widgets/adaptive_appbar_title.dart
+++ b/lib/widgets/adaptive_appbar_title.dart
@@ -7,9 +7,11 @@ class AdaptiveAppBarTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FittedBox(
-      fit: BoxFit.scaleDown,
-      child: Text(text, maxLines: maxLines, textAlign: TextAlign.center),
+    return Text(
+      text,
+      maxLines: maxLines,
+      textAlign: TextAlign.center,
+      overflow: TextOverflow.ellipsis,
     );
   }
 }


### PR DESCRIPTION
## Résumé
- supprime `FittedBox` dans `AdaptiveAppBarTitle`
- laisse `Text` gérer les retours à la ligne

## Tests
- `flutter analyze` *(échoue : commande introuvable)*
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6873e1b75810832d95bc86dfe44c363d