### PR TITLE
Implement marquee scrolling for AppBar titles

### DIFF
--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -15,7 +15,10 @@ class CadreDetailScreen extends StatelessWidget {
           tag: 'cadreTitle-${cadre.cadre}',
           child: Material(
             color: Colors.transparent,
-            child: AdaptiveAppBarTitle(cadre.cadre),
+            child: AdaptiveAppBarTitle(
+              cadre.cadre,
+              maxLines: 1,
+            ),
           ),
         ),
       ),

--- a/lib/screens/cadre_list_screen.dart
+++ b/lib/screens/cadre_list_screen.dart
@@ -36,7 +36,10 @@ class _CadreListScreenState extends State<CadreListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const AdaptiveAppBarTitle("Cadres d'enquête"),
+        title: const AdaptiveAppBarTitle(
+          "Cadres d'enquête",
+          maxLines: 1,
+        ),
       ),
       body: Column(
         children: [

--- a/lib/screens/category_screen.dart
+++ b/lib/screens/category_screen.dart
@@ -66,7 +66,10 @@ class _CategoryScreenState extends State<CategoryScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: AdaptiveAppBarTitle(widget.category?.title ?? 'Catégories'),
+        title: AdaptiveAppBarTitle(
+          widget.category?.title ?? 'Catégories',
+          maxLines: 1,
+        ),
       ),
       body: FutureBuilder<List<FamilleInfractions>>(
         future: _families,

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -42,7 +42,10 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const AdaptiveAppBarTitle('Favoris'),
+        title: const AdaptiveAppBarTitle(
+          'Favoris',
+          maxLines: 1,
+        ),
       ),
       body: AnimatedSwitcher(
         duration: const Duration(milliseconds: 300),

--- a/lib/screens/fiche_list_screen.dart
+++ b/lib/screens/fiche_list_screen.dart
@@ -48,7 +48,10 @@ class _FicheListScreenState extends State<FicheListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: AdaptiveAppBarTitle(widget.famille.famille ?? 'Infractions'),
+        title: AdaptiveAppBarTitle(
+          widget.famille.famille ?? 'Infractions',
+          maxLines: 1,
+        ),
       ),
       body: Column(
         children: [

--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -12,7 +12,10 @@ class InfractionDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: AdaptiveAppBarTitle(infraction.type ?? 'Infraction'),
+        title: AdaptiveAppBarTitle(
+          infraction.type ?? 'Infraction',
+          maxLines: 1,
+        ),
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -57,7 +57,10 @@ class _SearchScreenState extends State<SearchScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const AdaptiveAppBarTitle('Recherche'),
+        title: const AdaptiveAppBarTitle(
+          'Recherche',
+          maxLines: 1,
+        ),
       ),
       body: Column(
         children: [

--- a/lib/screens/theme_screen.dart
+++ b/lib/screens/theme_screen.dart
@@ -17,7 +17,10 @@ class ThemeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const AdaptiveAppBarTitle('Th\u00e8mes'),
+        title: const AdaptiveAppBarTitle(
+          'Th\u00e8mes',
+          maxLines: 1,
+        ),
       ),
       body: ListView.separated(
         padding: const EdgeInsets.all(16),

--- a/lib/widgets/adaptive_appbar_title.dart
+++ b/lib/widgets/adaptive_appbar_title.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:marquee/marquee.dart';
 
 class AdaptiveAppBarTitle extends StatelessWidget {
   final String text;
@@ -7,11 +8,40 @@ class AdaptiveAppBarTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      text,
-      maxLines: maxLines,
-      textAlign: TextAlign.center,
-      overflow: TextOverflow.ellipsis,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final style = Theme.of(context).appBarTheme.titleTextStyle ??
+            Theme.of(context).textTheme.titleLarge;
+        final textPainter = TextPainter(
+          text: TextSpan(text: text, style: style),
+          maxLines: 1,
+          textDirection: TextDirection.ltr,
+        )..layout();
+
+        final bool needsScroll = maxLines == 1 &&
+            textPainter.width > constraints.maxWidth;
+
+        if (needsScroll) {
+          return SizedBox(
+            height: kToolbarHeight,
+            child: Marquee(
+              text: text,
+              blankSpace: 32.0,
+              velocity: 40.0,
+              startAfter: const Duration(seconds: 1),
+              style: style,
+            ),
+          );
+        }
+
+        return Text(
+          text,
+          maxLines: maxLines,
+          textAlign: TextAlign.center,
+          overflow: TextOverflow.ellipsis,
+          style: style,
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   url_launcher: ^6.3.1
   shared_preferences: ^2.2.2
+  marquee: ^2.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add the `marquee` package
- update `AdaptiveAppBarTitle` to scroll overflowing text
- use one-line scrolling titles across screens

## Testing
- `dart format -o none --set-exit-if-changed lib pubspec.yaml`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6873e3b14420832d932a97ed0326fb35