### PR TITLE
Fix appbar label color

### DIFF
--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -10,7 +10,8 @@ class AppTheme {
     scaffoldBackgroundColor: Color(0xFFFAF9F6),
     appBarTheme: const AppBarTheme(
       backgroundColor: Color(0xFF122046),
-      foregroundColor: Color(0xFFFAF9F6),
+      foregroundColor: Colors.white,
+      titleTextStyle: TextStyle(color: Colors.white),
       elevation: 2,
     ),
     cardTheme: CardThemeData(
@@ -32,6 +33,7 @@ class AppTheme {
     appBarTheme: const AppBarTheme(
       backgroundColor: Color(0xFF122046),
       foregroundColor: Colors.white,
+      titleTextStyle: TextStyle(color: Colors.white),
       elevation: 2,
     ),
     cardTheme: CardThemeData(


### PR DESCRIPTION
## Summary
- set AppBar foregroundColor to white
- apply white titleTextStyle for AppBar in both themes

## Testing
- `flutter format lib/utils/theme.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873e6eaa000832db184e5f4281b51ef