### PR TITLE
Ajout dialogue de signalement

### DIFF
--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/cadre.dart';
 import '../widgets/gradient_expansion_tile.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../widgets/report_dialog.dart';
 
 class CadreDetailScreen extends StatelessWidget {
   final Cadre cadre;
@@ -21,6 +22,17 @@ class CadreDetailScreen extends StatelessWidget {
             ),
           ),
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.flag),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) => ReportDialog(ficheId: cadre.cadre),
+              );
+            },
+          ),
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../models/infraction.dart';
 import '../widgets/gradient_expansion_tile.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../widgets/report_dialog.dart';
 
 class InfractionDetailScreen extends StatelessWidget {
   final Infraction infraction;
@@ -16,6 +17,17 @@ class InfractionDetailScreen extends StatelessWidget {
           infraction.type ?? 'Infraction',
           maxLines: 1,
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.flag),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) => ReportDialog(ficheId: infraction.id),
+              );
+            },
+          ),
+        ],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),

--- a/lib/utils/anomaly_reporter.dart
+++ b/lib/utils/anomaly_reporter.dart
@@ -1,0 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AnomalyReporter {
+  static Future<void> sendReport(String ficheId, String message) {
+    return FirebaseFirestore.instance.collection('reports').add({
+      'ficheId': ficheId,
+      'message': message,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+  }
+}

--- a/lib/widgets/report_dialog.dart
+++ b/lib/widgets/report_dialog.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import '../utils/anomaly_reporter.dart';
+
+class ReportDialog extends StatefulWidget {
+  final String ficheId;
+  const ReportDialog({super.key, required this.ficheId});
+
+  @override
+  State<ReportDialog> createState() => _ReportDialogState();
+}
+
+class _ReportDialogState extends State<ReportDialog> {
+  final TextEditingController _controller = TextEditingController();
+  bool _sending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Signaler une erreur'),
+      content: TextField(
+        controller: _controller,
+        maxLines: 3,
+        decoration: const InputDecoration(
+          hintText: 'Décrivez le problème...',
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _sending
+              ? null
+              : () async {
+                  final message = _controller.text.trim();
+                  if (message.isEmpty) return;
+                  setState(() => _sending = true);
+                  await AnomalyReporter.sendReport(widget.ficheId, message);
+                  if (mounted) Navigator.of(context).pop();
+                },
+          child: const Text('Envoyer'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- ajout d'`AnomalyReporter.sendReport` pour envoyer un message dans Firestore
- création du widget `ReportDialog` avec un champ texte et un bouton "Envoyer"
- ajout d'un bouton drapeau dans les écrans de détail pour ouvrir le dialogue

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_687403f8e2fc832dae7422d04e002340