### PR TITLE
Configure Firebase options

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,10 +4,13 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:upgrader/upgrader.dart';
 import 'screens/home_screen.dart';
 import 'utils/theme.dart';
+import 'firebase_options.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   await FirebaseAnalytics.instance.logAppOpen();
   runApp(const OPJFichesApp());
 }


### PR DESCRIPTION
## Summary
- add `firebase_options.dart` import
- initialize Firebase with `DefaultFirebaseOptions`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687415cc01b8832d9f737eb38ccbbbab