### PR TITLE
Change app name to PJ +

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="poljud"
+        android:label="PJ +"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,8 +6,8 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>Poljud</string>
+       <key>CFBundleDisplayName</key>
+       <string>PJ +</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="poljud">
+  <meta name="apple-mobile-web-app-title" content="PJ +">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>poljud</title>
+  <title>PJ +</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "poljud",
-    "short_name": "poljud",
+    "name": "PJ +",
+    "short_name": "PJ +",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
## Summary
- rename the app to **PJ +** on Android
- rename the app on iOS
- update web manifest and index with new title

## Testing
- `flutter test` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*
- `flutter build ios` *(fails: command not found)*
- `flutter build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741eb444fc832d9275b3d64b545139