### PR TITLE
Amélioration du système de signalement

### DIFF
--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -25,12 +25,19 @@ class CadreDetailScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.flag),
-            onPressed: () {
-              showDialog(
+            onPressed: () async {
+              final ok = await showDialog<bool>(
                 context: context,
                 builder: (context) =>
                     ReportDialog(ficheId: cadre.cadre, fiche: cadre),
               );
+              if (ok == true && context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                      content:
+                          Text('Merci, votre signalement a été envoyé.')),
+                );
+              }
             },
           ),
         ],

--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -20,12 +20,19 @@ class InfractionDetailScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.flag),
-            onPressed: () {
-              showDialog(
+            onPressed: () async {
+              final ok = await showDialog<bool>(
                 context: context,
                 builder: (context) =>
                     ReportDialog(ficheId: infraction.id, fiche: infraction),
               );
+              if (ok == true && context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                      content:
+                          Text('Merci, votre signalement a été envoyé.')),
+                );
+              }
             },
           ),
         ],

--- a/lib/utils/anomaly_reporter.dart
+++ b/lib/utils/anomaly_reporter.dart
@@ -49,6 +49,7 @@ class AnomalyReporter {
       'appVersion': '${packageInfo.version}+${packageInfo.buildNumber}',
       'device': deviceData,
       'fiche': ficheSummary,
+      'status': 'pending',
     });
   }
 }

--- a/lib/widgets/report_dialog.dart
+++ b/lib/widgets/report_dialog.dart
@@ -57,6 +57,10 @@ class _ReportDialogState extends State<ReportDialog> {
       ),
       actions: [
         TextButton(
+          onPressed: _sending ? null : () => Navigator.of(context).pop(false),
+          child: const Text('Annuler'),
+        ),
+        TextButton(
           onPressed: _sending
               ? null
               : () async {
@@ -69,7 +73,7 @@ class _ReportDialogState extends State<ReportDialog> {
                     message,
                     ficheSummary: _buildSummary(),
                   );
-                  if (mounted) Navigator.of(context).pop();
+                  if (mounted) Navigator.of(context).pop(true);
 
                 },
           child: const Text('Envoyer'),


### PR DESCRIPTION
## Summary
- accuse le signalement avec un Snackbar après l'envoi
- permet d'annuler l'envoi via le dialogue
- marque chaque rapport comme "pending" dans la base

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687431c04ff4832da7621796de67d786