### PR TITLE
Ajout des IDs de test AdMob en debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ samples, guidance on mobile development, and a full API reference.
 
 L'application vérifie désormais automatiquement si une nouvelle version est disponible sur l'App Store ou sur Google Play grâce au plugin **upgrader**. Lorsque c'est le cas, une fenêtre s'affiche pour proposer à l'utilisateur de mettre à jour ou de continuer.
 
+## Publicité AdMob
+
+En mode *debug*, l'application utilise désormais les identifiants de test
+fournis par Google afin de pouvoir tester les bannières et interstitiels sans
+générer de clics réels.
+
 ## Licence
 
 Ce projet est distribué sous licence MIT. Voir [LICENSE](LICENSE) pour plus d'informations.

--- a/lib/utils/ad_helper.dart
+++ b/lib/utils/ad_helper.dart
@@ -1,22 +1,49 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 /// Utilitaire renvoyant les identifiants AdMob selon la plateforme.
 class AdHelper {
-  /// ID de l'application AdMob (identique pour Android et iOS ici).
-  static const String appId = 'ca-app-pub-4176691748354941~1821840757';
+  /// ID de l'application AdMob, différent en mode debug pour utiliser
+  /// les identifiants de test recommandés par Google.
+  static String get appId {
+    if (Platform.isAndroid) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544~3347511713'
+          : 'ca-app-pub-4176691748354941~1821840757';
+    } else if (Platform.isIOS) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544~1458002511'
+          : 'ca-app-pub-4176691748354941~1821840757';
+    }
+    throw UnsupportedError('Platform not supported');
+  }
 
   /// Identifiant de la bannière d'accueil.
+  /// Utilise les unités de test en mode debug.
   static String get bannerHome {
-    if (Platform.isAndroid || Platform.isIOS) {
-      return 'ca-app-pub-4176691748354941/5507635012';
+    if (Platform.isAndroid) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/6300978111'
+          : 'ca-app-pub-4176691748354941/5507635012';
+    } else if (Platform.isIOS) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/2934735716'
+          : 'ca-app-pub-4176691748354941/5507635012';
     }
     throw UnsupportedError('Platform not supported');
   }
 
   /// Identifiant de l'interstitiel affiché dans les écrans de détail.
+  /// Utilise les unités de test en mode debug.
   static String get interstitialDetail {
-    if (Platform.isAndroid || Platform.isIOS) {
-      return 'ca-app-pub-4176691748354941/2302887173';
+    if (Platform.isAndroid) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/1033173712'
+          : 'ca-app-pub-4176691748354941/2302887173';
+    } else if (Platform.isIOS) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/4411468910'
+          : 'ca-app-pub-4176691748354941/2302887173';
     }
     throw UnsupportedError('Platform not supported');
   }


### PR DESCRIPTION
## Résumé
- utilise désormais les identifiants de test AdMob lorsque l'application est lancée en mode debug
- documente ce comportement dans le README

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_687512d5ab90832d93bc562acf80fc4a