### PR TITLE
Implement new ad placements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,10 +16,10 @@ Future<void> main() async {
   );
   // Initialisation AdMob pour activer la pub.
   MobileAds.instance.initialize();
-  // Préchargement d'un interstitiel.
-  InterstitialAdHelper.load();
   await FirebaseAnalytics.instance.logAppOpen();
   runApp(const OPJFichesApp());
+  // Interstitiel au démarrage.
+  InterstitialAdHelper.show(adUnitId: AdHelper.interstitialStart);
 }
 
 class OPJFichesApp extends StatelessWidget {

--- a/lib/screens/cadre_detail_screen.dart
+++ b/lib/screens/cadre_detail_screen.dart
@@ -3,6 +3,7 @@ import '../models/cadre.dart';
 import '../widgets/gradient_expansion_tile.dart';
 import '../widgets/adaptive_appbar_title.dart';
 import '../widgets/report_dialog.dart';
+import '../widgets/ad_banner.dart';
 
 class CadreDetailScreen extends StatelessWidget {
   final Cadre cadre;
@@ -138,6 +139,8 @@ class CadreDetailScreen extends StatelessWidget {
               ),
             ),
           ),
+          const SizedBox(height: 16),
+          const AdBanner(),
         ],
       ),
     );

--- a/lib/screens/cadre_list_screen.dart
+++ b/lib/screens/cadre_list_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter/services.dart' show rootBundle;
 import '../models/cadre.dart';
 import 'cadre_detail_screen.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../widgets/ad_banner.dart';
+import '../utils/ad_event_manager.dart';
 
 class CadreListScreen extends StatefulWidget {
   const CadreListScreen({super.key});
@@ -50,8 +52,11 @@ class _CadreListScreenState extends State<CadreListScreen> {
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.builder(
                       key: const ValueKey('list'),
-                      itemCount: cadres.length,
+                      itemCount: cadres.length + 1,
                       itemBuilder: (context, index) {
+                        if (index == cadres.length) {
+                          return const AdBanner();
+                        }
                         final cadre = cadres[index];
                         return Card(
                           margin: const EdgeInsets.symmetric(
@@ -70,6 +75,7 @@ class _CadreListScreenState extends State<CadreListScreen> {
                             trailing:
                                 const Icon(Icons.chevron_right_rounded),
                             onTap: () {
+                              AdEventManager.onCadreOpened();
                               Navigator.of(context).push(
                                 PageRouteBuilder(
                                   pageBuilder: (_, animation, __) =>

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -6,6 +6,8 @@ import '../widgets/infraction_card.dart';
 import '../utils/favorites_manager.dart';
 import 'infraction_detail_screen.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../widgets/ad_banner.dart';
+import '../utils/ad_event_manager.dart';
 
 class FavoritesScreen extends StatefulWidget {
   const FavoritesScreen({super.key});
@@ -54,12 +56,16 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             : favorites.isEmpty
                 ? const Center(child: Text('Aucun favori'))
                 : ListView.builder(
-                    itemCount: favorites.length,
+                    itemCount: favorites.length + 1,
                     itemBuilder: (context, index) {
+                      if (index == favorites.length) {
+                        return const AdBanner();
+                      }
                       final infraction = favorites[index];
                       return InfractionCard(
                         infraction: infraction,
                         onTap: () {
+                          AdEventManager.onInfractionViewed();
                           Navigator.of(context)
                               .push(
                                 PageRouteBuilder(

--- a/lib/screens/fiche_list_screen.dart
+++ b/lib/screens/fiche_list_screen.dart
@@ -4,7 +4,7 @@ import '../widgets/infraction_card.dart';
 import '../widgets/search_bar.dart';
 import 'infraction_detail_screen.dart';
 import '../widgets/adaptive_appbar_title.dart';
-import '../widgets/interstitial_ad_helper.dart';
+import '../utils/ad_event_manager.dart';
 
 class FicheListScreen extends StatefulWidget {
   final FamilleInfractions famille;
@@ -73,7 +73,7 @@ class _FicheListScreenState extends State<FicheListScreen> {
                         return InfractionCard(
                           infraction: infraction,
                           onTap: () {
-                            InterstitialAdHelper.show();
+                            AdEventManager.onInfractionViewed();
                             Navigator.of(context).push(
                               PageRouteBuilder(
                                 pageBuilder: (_, animation, __) => FadeTransition(

--- a/lib/screens/infraction_detail_screen.dart
+++ b/lib/screens/infraction_detail_screen.dart
@@ -4,6 +4,7 @@ import '../models/infraction.dart';
 import '../widgets/gradient_expansion_tile.dart';
 import '../widgets/adaptive_appbar_title.dart';
 import '../widgets/report_dialog.dart';
+import '../widgets/ad_banner.dart';
 
 class InfractionDetailScreen extends StatelessWidget {
   final Infraction infraction;
@@ -311,6 +312,8 @@ class InfractionDetailScreen extends StatelessWidget {
                 ],
               ),
             ),
+          const SizedBox(height: 16),
+          const AdBanner(),
         ],
       ),
     );

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/infraction_card.dart';
 import '../widgets/search_bar.dart';
 import 'infraction_detail_screen.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../utils/ad_event_manager.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -81,6 +82,7 @@ class _SearchScreenState extends State<SearchScreen> {
                         return InfractionCard(
                           infraction: infraction,
                           onTap: () {
+                            AdEventManager.onInfractionViewed();
                             Navigator.of(context).push(
                               PageRouteBuilder(
                                 pageBuilder: (_, animation, __) => FadeTransition(

--- a/lib/utils/ad_event_manager.dart
+++ b/lib/utils/ad_event_manager.dart
@@ -1,0 +1,24 @@
+import 'interstitial_ad_helper.dart';
+import 'ad_helper.dart';
+
+/// Gère l'affichage conditionnel des interstitiels.
+class AdEventManager {
+  AdEventManager._();
+
+  static int _infractionViews = 0;
+
+  /// À appeler lorsqu'une fiche infraction est consultée.
+  static void onInfractionViewed() {
+    _infractionViews++;
+    if (_infractionViews >= 3) {
+      _infractionViews = 0;
+      InterstitialAdHelper.show(adUnitId: AdHelper.interstitialEvent);
+    }
+  }
+
+  /// À appeler lorsqu'un cadre d'enquête est ouvert.
+  static void onCadreOpened() {
+    _infractionViews = 0;
+    InterstitialAdHelper.show(adUnitId: AdHelper.interstitialEvent);
+  }
+}

--- a/lib/utils/ad_helper.dart
+++ b/lib/utils/ad_helper.dart
@@ -47,4 +47,22 @@ class AdHelper {
     }
     throw UnsupportedError('Platform not supported');
   }
+
+  /// Identifiant de l'interstitiel affiché au démarrage de l'application.
+  static String get interstitialStart => interstitialDetail;
+
+  /// Identifiant de l'interstitiel affiché après consultation de plusieurs
+  /// fiches ou ouverture d'un cadre d'enquête.
+  static String get interstitialEvent {
+    if (Platform.isAndroid) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/1033173712'
+          : 'ca-app-pub-4176691748354941/6118843251';
+    } else if (Platform.isIOS) {
+      return kDebugMode
+          ? 'ca-app-pub-3940256099942544/4411468910'
+          : 'ca-app-pub-4176691748354941/6118843251';
+    }
+    throw UnsupportedError('Platform not supported');
+  }
 }

--- a/lib/widgets/interstitial_ad_helper.dart
+++ b/lib/widgets/interstitial_ad_helper.dart
@@ -1,32 +1,24 @@
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../utils/ad_helper.dart';
 
-/// Gestionnaire simple d'interstitiel.
+/// Utilitaire minimaliste pour afficher un interstitiel à la demande.
 class InterstitialAdHelper {
   InterstitialAdHelper._();
-  static InterstitialAd? _ad;
 
-  /// Charge l'interstitiel si nécessaire.
-  static void load() {
+  /// Charge et affiche immédiatement un interstitiel.
+  static void show({required String adUnitId}) {
     InterstitialAd.load(
-      adUnitId: AdHelper.interstitialDetail,
+      adUnitId: adUnitId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
-        onAdLoaded: (ad) => _ad = ad,
-        onAdFailedToLoad: (_) => _ad = null,
+        onAdLoaded: (ad) {
+          ad.fullScreenContentCallback = FullScreenContentCallback(
+            onAdDismissedFullScreenContent: (ad) => ad.dispose(),
+          );
+          ad.show();
+        },
+        onAdFailedToLoad: (_) {},
       ),
     );
-  }
-
-  /// Affiche l'interstitiel s'il est prêt.
-  static void show() {
-    _ad?.fullScreenContentCallback = FullScreenContentCallback(
-      onAdDismissedFullScreenContent: (ad) {
-        ad.dispose();
-        _ad = null;
-        load();
-      },
-    );
-    _ad?.show();
   }
 }


### PR DESCRIPTION
## Summary
- manage startup and event-triggered interstitial ads
- load ads on opening the app and after viewing several entries
- show ads at the bottom of favourites, cadres and detail pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751cf1028c832da27c73a39a7949b0