### PR TITLE
Update import path for ad event manager

### DIFF
--- a/lib/utils/ad_event_manager.dart
+++ b/lib/utils/ad_event_manager.dart
@@ -1,4 +1,4 @@
-import 'interstitial_ad_helper.dart';
+import '../widgets/interstitial_ad_helper.dart';
 import 'ad_helper.dart';
 
 /// Gère l'affichage conditionnel des interstitiels.


### PR DESCRIPTION
## Summary
- fix the path for the interstitial ad helper import

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_687523377154832db2853ea7d42e5c1d