### PR TITLE
Fix ad placement on favorites and cadre screens

### DIFF
--- a/lib/screens/cadre_list_screen.dart
+++ b/lib/screens/cadre_list_screen.dart
@@ -52,11 +52,8 @@ class _CadreListScreenState extends State<CadreListScreen> {
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.builder(
                       key: const ValueKey('list'),
-                      itemCount: cadres.length + 1,
+                      itemCount: cadres.length,
                       itemBuilder: (context, index) {
-                        if (index == cadres.length) {
-                          return const AdBanner();
-                        }
                         final cadre = cadres[index];
                         return Card(
                           margin: const EdgeInsets.symmetric(
@@ -72,8 +69,7 @@ class _CadreListScreenState extends State<CadreListScreen> {
                                 ),
                               ),
                             ),
-                            trailing:
-                                const Icon(Icons.chevron_right_rounded),
+                            trailing: const Icon(Icons.chevron_right_rounded),
                             onTap: () {
                               AdEventManager.onCadreOpened();
                               Navigator.of(context).push(
@@ -92,6 +88,7 @@ class _CadreListScreenState extends State<CadreListScreen> {
                     ),
             ),
           ),
+          const AdBanner(),
         ],
       ),
     );

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -49,39 +49,43 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
           maxLines: 1,
         ),
       ),
-      body: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 300),
-        child: isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : favorites.isEmpty
-                ? const Center(child: Text('Aucun favori'))
-                : ListView.builder(
-                    itemCount: favorites.length + 1,
-                    itemBuilder: (context, index) {
-                      if (index == favorites.length) {
-                        return const AdBanner();
-                      }
-                      final infraction = favorites[index];
-                      return InfractionCard(
-                        infraction: infraction,
-                        onTap: () {
-                          AdEventManager.onInfractionViewed();
-                          Navigator.of(context)
-                              .push(
-                                PageRouteBuilder(
-                                  pageBuilder: (_, animation, __) =>
-                                      FadeTransition(
-                                    opacity: animation,
-                                    child: InfractionDetailScreen(
-                                        infraction: infraction),
-                                  ),
-                                ),
-                              )
-                              .then((_) => loadFavorites());
-                        },
-                      );
-                    },
-                  ),
+      body: Column(
+        children: [
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : favorites.isEmpty
+                      ? const Center(child: Text('Aucun favori'))
+                      : ListView.builder(
+                          itemCount: favorites.length,
+                          itemBuilder: (context, index) {
+                            final infraction = favorites[index];
+                            return InfractionCard(
+                              infraction: infraction,
+                              onTap: () {
+                                AdEventManager.onInfractionViewed();
+                                Navigator.of(context)
+                                    .push(
+                                      PageRouteBuilder(
+                                        pageBuilder: (_, animation, __) =>
+                                            FadeTransition(
+                                          opacity: animation,
+                                          child: InfractionDetailScreen(
+                                              infraction: infraction),
+                                        ),
+                                      ),
+                                    )
+                                    .then((_) => loadFavorites());
+                              },
+                            );
+                          },
+                        ),
+            ),
+          ),
+          const AdBanner(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- keep banner ads fixed at bottom of favorites screen
- keep banner ads fixed at bottom of cadre list screen

## Testing
- `flutter test` *(fails: `bash: command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_687524b3f394832dac5ec6a8b1801433