### PR TITLE
Ajout ATT pour iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -21,8 +21,10 @@
   <!-- Identifiant AdMob de l'application -->
   <key>GADApplicationIdentifier</key>
   <string>ca-app-pub-4176691748354941~1821840757</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
+  <key>NSUserTrackingUsageDescription</key>
+  <string>Cette autorisation permet d\u2019afficher des publicités plus pertinentes.</string>
+        <key>CFBundleShortVersionString</key>
+        <string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:upgrader/upgrader.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 import 'screens/home_screen.dart';
 import 'utils/theme.dart';
 import 'utils/ad_helper.dart';
@@ -14,6 +15,8 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  // Demande d'autorisation de suivi publicitaire (ATT).
+  await AppTrackingTransparency.requestTrackingAuthorization();
   // Initialisation AdMob pour activer la pub.
   MobileAds.instance.initialize();
   await FirebaseAnalytics.instance.logAppOpen();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   upgrader: ^11.4.0
   device_info_plus: ^11.5.0
   package_info_plus: ^8.3.0
+  # Transparence du suivi publicitaire (App Tracking Transparency)
+  app_tracking_transparency: ^2.0.4
   # Publicité Google AdMob
   google_mobile_ads: ^5.1.0
 


### PR DESCRIPTION
## Résumé
- ajout de la dépendance `app_tracking_transparency`
- demande d'autorisation ATT au démarrage
- ajout de `NSUserTrackingUsageDescription` dans *Info.plist*

## Test
- `flutter analyze` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_687620a18d74832dbf22d1fe67efbf52