### PR TITLE
Ajout d'un module de quiz

### DIFF
--- a/lib/models/quiz_question.dart
+++ b/lib/models/quiz_question.dart
@@ -1,0 +1,41 @@
+class QuizOption {
+  final String text;
+  final bool isCorrect;
+
+  QuizOption({required this.text, required this.isCorrect});
+
+  factory QuizOption.fromJson(Map<String, dynamic> json) => QuizOption(
+        text: json['text'] ?? '',
+        isCorrect: json['is_correct'] ?? false,
+      );
+}
+
+class QuizQuestion {
+  final String question;
+  final String theme;
+  final String cadre;
+  final String? acte;
+  final List<QuizOption> options;
+
+  QuizQuestion({
+    required this.question,
+    required this.theme,
+    required this.cadre,
+    this.acte,
+    required this.options,
+  });
+
+  factory QuizQuestion.fromJson(Map<String, dynamic> json) => QuizQuestion(
+        question: json['question'] ?? '',
+        theme: json['theme'] ?? '',
+        cadre: json['cadre'] ?? '',
+        acte: json['acte'],
+        options: (json['options'] as List? ?? [])
+            .whereType<Map>()
+            .map((e) => QuizOption.fromJson(e.cast<String, dynamic>()))
+            .toList(),
+      );
+
+  bool isCorrect(int index) =>
+      index >= 0 && index < options.length && options[index].isCorrect;
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'theme_screen.dart';
 import 'favorites_screen.dart';
 import 'cadre_list_screen.dart';
 import 'search_screen.dart';
+import 'quiz_menu_screen.dart';
 import '../widgets/ad_banner.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -100,6 +101,24 @@ class HomeScreen extends StatelessWidget {
                         pageBuilder: (_, animation, __) => FadeTransition(
                           opacity: animation,
                           child: const FavoritesScreen(),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 16),
+              FractionallySizedBox(
+                widthFactor: 0.85,
+                child: _ModernGradientButton(
+                  icon: Icons.quiz,
+                  label: 'Quiz',
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      PageRouteBuilder(
+                        pageBuilder: (_, animation, __) => FadeTransition(
+                          opacity: animation,
+                          child: const QuizMenuScreen(),
                         ),
                       ),
                     );

--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../models/quiz_question.dart';
+import '../utils/json_loader.dart';
+import '../widgets/adaptive_appbar_title.dart';
+
+class QuizCadreScreen extends StatefulWidget {
+  const QuizCadreScreen({super.key});
+
+  @override
+  State<QuizCadreScreen> createState() => _QuizCadreScreenState();
+}
+
+class _QuizCadreScreenState extends State<QuizCadreScreen> {
+  List<QuizQuestion> _questions = [];
+  int _current = 0;
+  int _score = 0;
+  int _selected = -1;
+  bool _loading = true;
+  bool _finished = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadQuestions();
+  }
+
+  Future<void> _loadQuestions() async {
+    final data = await loadJsonWithComments('assets/data/quiz_cadre_enquete.json');
+    final List<dynamic> list = json.decode(data);
+    setState(() {
+      _questions = list
+          .whereType<Map>()
+          .map((e) => QuizQuestion.fromJson(e.cast<String, dynamic>()))
+          .toList();
+      _loading = false;
+    });
+  }
+
+  void _next() {
+    if (_selected == -1) return;
+    if (_questions[_current].isCorrect(_selected)) {
+      _score++;
+    }
+    if (_current < _questions.length - 1) {
+      setState(() {
+        _current++;
+        _selected = -1;
+      });
+    } else {
+      setState(() {
+        _finished = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const AdaptiveAppBarTitle('Quiz cadres d\'enquête', maxLines: 1),
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_finished) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const AdaptiveAppBarTitle('Quiz cadres d\'enquête', maxLines: 1),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Score : \$_score / \${_questions.length}',
+                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Fermer'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final question = _questions[_current];
+    return Scaffold(
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Quiz cadres d\'enquête', maxLines: 1),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              question.question,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: question.options.length,
+                itemBuilder: (context, index) {
+                  final opt = question.options[index];
+                  return RadioListTile<int>(
+                    value: index,
+                    groupValue: _selected,
+                    onChanged: (v) {
+                      setState(() {
+                        _selected = v ?? -1;
+                      });
+                    },
+                    title: Text(opt.text),
+                  );
+                },
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _selected == -1 ? null : _next,
+              child: Text(
+                _current < _questions.length - 1 ? 'Suivant' : 'Terminer',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/quiz_menu_screen.dart
+++ b/lib/screens/quiz_menu_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import '../widgets/adaptive_appbar_title.dart';
+import 'quiz_cadre_screen.dart';
+
+class QuizMenuScreen extends StatelessWidget {
+  const QuizMenuScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Quiz', maxLines: 1),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 220,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const QuizCadreScreen(),
+                    ),
+                  );
+                },
+                child: const Text('Quiz cadres d\'enquête'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: 220,
+              child: ElevatedButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('À venir')),
+                  );
+                },
+                child: const Text('Quiz infractions'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ flutter:
     - assets/data/fiches.json
     - assets/data/cadres.json
     - assets/data/loader_test.json
+    - assets/data/quiz_cadre_enquete.json
     - assets/images/
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
## Résumé
- enregistrement du nouvel asset `quiz_cadre_enquete.json`
- ajout du modèle `QuizQuestion`
- création des écrans `QuizMenuScreen` et `QuizCadreScreen`
- ajout d'un bouton « Quiz » depuis l'écran d'accueil

## Tests
- `flutter analyze` *(échoue : commande introuvable)*
- `flutter run` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a49cbce00832d82f0e569aff284c3