### PR TITLE
Limite le quiz à 12 questions

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -29,10 +29,13 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
     final data = await loadJsonWithComments('assets/data/quiz_cadre_enquete.json');
     final List<dynamic> list = json.decode(data);
     setState(() {
-      _questions = list
+      final questions = list
           .whereType<Map>()
           .map((e) => QuizQuestion.fromJson(e.cast<String, dynamic>()))
-          .toList();
+          .toList()
+        ..shuffle();
+      _questions =
+          questions.length > 12 ? questions.take(12).toList() : questions;
       _loading = false;
     });
   }


### PR DESCRIPTION
## Résumé
- mélange les questions du quiz pour les cadres d'enquête
- conserve au maximum 12 questions pour le quiz

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a524e30f4832db3f88bd888b636c5