### PR TITLE
Ajout sélection multiple dans le quiz cadres

### DIFF
--- a/lib/models/quiz_question.dart
+++ b/lib/models/quiz_question.dart
@@ -36,6 +36,15 @@ class QuizQuestion {
             .toList(),
       );
 
-  bool isCorrect(int index) =>
-      index >= 0 && index < options.length && options[index].isCorrect;
+  /// Indices des options marquées comme correctes.
+  Set<int> get correctIndices => {
+        for (var i = 0; i < options.length; i++)
+          if (options[i].isCorrect) i
+      };
+
+  /// Vérifie si [selection] correspond exactement aux bonnes réponses.
+  bool isCorrectSet(Set<int> selection) {
+    final correct = correctIndices;
+    return selection.length == correct.length && selection.containsAll(correct);
+  }
 }

--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -15,7 +15,7 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
   List<QuizQuestion> _questions = [];
   int _current = 0;
   int _score = 0;
-  int _selected = -1;
+  Set<int> _selectedIndices = {};
   bool _loading = true;
   bool _finished = false;
 
@@ -57,12 +57,15 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
               final opt = question.options[index];
               return Card(
                 margin: const EdgeInsets.symmetric(vertical: 4),
-                child: RadioListTile<int>(
-                  value: index,
-                  groupValue: _selected,
+                child: CheckboxListTile(
+                  value: _selectedIndices.contains(index),
                   onChanged: (v) {
                     setState(() {
-                      _selected = v ?? -1;
+                      if (v == true) {
+                        _selectedIndices.add(index);
+                      } else {
+                        _selectedIndices.remove(index);
+                      }
                     });
                   },
                   title: Text(opt.text),
@@ -76,14 +79,14 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
   }
 
   void _next() {
-    if (_selected == -1) return;
-    if (_questions[_current].isCorrect(_selected)) {
+    if (_selectedIndices.isEmpty) return;
+    if (_questions[_current].isCorrectSet(_selectedIndices)) {
       _score++;
     }
     if (_current < _questions.length - 1) {
       setState(() {
         _current++;
-        _selected = -1;
+        _selectedIndices = {};
       });
     } else {
       setState(() {
@@ -150,7 +153,7 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
               ),
             ),
             ElevatedButton(
-              onPressed: _selected == -1 ? null : _next,
+              onPressed: _selectedIndices.isEmpty ? null : _next,
               child: Text(
                 _current < _questions.length - 1 ? 'Suivant' : 'Terminer',
               ),


### PR DESCRIPTION
## Résumé
- adaptation du modèle `QuizQuestion` pour gérer plusieurs réponses correctes via `isCorrectSet`
- mise à jour de `QuizCadreScreen` pour gérer une sélection multiple et vérifier la réponse avec la nouvelle méthode

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a55363c60832d9291665d2b9616a2