### PR TITLE
Animation feedback couleur dans le quiz

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -18,6 +18,7 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
   Set<int> _selectedIndices = {};
   bool _loading = true;
   bool _finished = false;
+  Color? _feedbackColor;
 
   @override
   void initState() {
@@ -80,19 +81,27 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
 
   void _next() {
     if (_selectedIndices.isEmpty) return;
-    if (_questions[_current].isCorrectSet(_selectedIndices)) {
+    final correct = _questions[_current].isCorrectSet(_selectedIndices);
+    if (correct) {
       _score++;
     }
-    if (_current < _questions.length - 1) {
+
+    setState(() {
+      _feedbackColor = correct ? Colors.green : Colors.red;
+    });
+
+    Future.delayed(const Duration(milliseconds: 300)).then((_) {
+      if (!mounted) return;
       setState(() {
-        _current++;
-        _selectedIndices = {};
+        _feedbackColor = null;
+        if (_current < _questions.length - 1) {
+          _current++;
+          _selectedIndices = {};
+        } else {
+          _finished = true;
+        }
       });
-    } else {
-      setState(() {
-        _finished = true;
-      });
-    }
+    });
   }
 
   @override
@@ -135,7 +144,10 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
       appBar: AppBar(
         title: const AdaptiveAppBarTitle('Quiz cadres d\'enquête', maxLines: 1),
       ),
-      body: Padding(
+      body: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        color: _feedbackColor ?? Theme.of(context).scaffoldBackgroundColor,
+        child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -159,6 +171,7 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
               ),
             ),
           ],
+        ),
         ),
       ),
     );


### PR DESCRIPTION
## Résumé
- ajout d'un champ `_feedbackColor` pour suivre la couleur d'évaluation
- utilisation d'un `AnimatedContainer` pour animer la couleur de fond
- modification de la fonction `_next()` pour afficher la couleur pendant 300 ms avant de passer à la question suivante

## Tests
- `flutter test --run-skipped` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a56567f48832d8698a3500a017872