### PR TITLE
Affichage du score avec pourcentage dans le quiz

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -124,9 +124,16 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                'Score : \$_score / \${_questions.length}',
-                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              Builder(
+                builder: (context) {
+                  final percent =
+                      (_score / _questions.length * 100).toStringAsFixed(1);
+                  return Text(
+                    'Score : \$_score / \${_questions.length} ($percent\u202f%)',
+                    style:
+                        const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  );
+                },
               ),
               const SizedBox(height: 16),
               ElevatedButton(


### PR DESCRIPTION
## Summary
- calcul du pourcentage de réussite dans `quiz_cadre_screen.dart`
- affichage du score total avec le pourcentage obtenu

## Testing
- `flutter analyze` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a665eefd8832d92631878e19e9286