### PR TITLE
Ajoute un bouton Statistiques dans le menu du quiz

### DIFF
--- a/lib/screens/quiz_menu_screen.dart
+++ b/lib/screens/quiz_menu_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../widgets/adaptive_appbar_title.dart';
 import 'quiz_cadre_screen.dart';
+import 'quiz_stats_screen.dart';
 
 class QuizMenuScreen extends StatelessWidget {
   const QuizMenuScreen({super.key});
@@ -38,6 +39,20 @@ class QuizMenuScreen extends StatelessWidget {
                   );
                 },
                 child: const Text('Quiz infractions'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: 220,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const QuizStatsScreen(),
+                    ),
+                  );
+                },
+                child: const Text('Statistiques'),
               ),
             ),
           ],

--- a/lib/screens/quiz_stats_screen.dart
+++ b/lib/screens/quiz_stats_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../widgets/adaptive_appbar_title.dart';
+
+class QuizStatsScreen extends StatelessWidget {
+  const QuizStatsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Statistiques', maxLines: 1),
+      ),
+      body: const Center(
+        child: Text('À venir'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- ajoute un bouton "Statistiques" dans `quiz_menu_screen.dart`
- crée l'écran `QuizStatsScreen`

## Test
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688a68ae9418832d8140e9a0e8ed5786