### PR TITLE
Fix quiz score display

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -157,8 +157,8 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
                 builder: (context) {
                   final percent =
                       (_score / _questions.length * 100).toStringAsFixed(1);
-                  return Text(
-                    'Score : \$_score / \${_questions.length} ($percent\u202f%)',
+                    return Text(
+                      'Score : $_score / ${_questions.length} ($percent\u202f%)',
                     style:
                         const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                   );


### PR DESCRIPTION
## Summary
- fix interpolation for quiz score display

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e23f580832d95f09fdb858f7f94