### PR TITLE
Improve quiz dialogs and stats animations

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -80,6 +80,50 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
     );
   }
 
+  Future<void> _showWrongAnswerDialog(List<String> correctOptions) async {
+    await showGeneralDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      barrierColor: Colors.black54,
+      transitionDuration: const Duration(milliseconds: 300),
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Center(
+          child: Material(
+            type: MaterialType.transparency,
+            child: ScaleTransition(
+              scale:
+                  CurvedAnimation(parent: animation, curve: Curves.easeOutBack),
+              child: AlertDialog(
+                title: Row(
+                  children: const [
+                    Icon(Icons.close, color: Colors.red),
+                    SizedBox(width: 8),
+                    Expanded(child: Text('Bonne(s) réponse(s)')),
+                  ],
+                ),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 4),
+                    for (final t in correctOptions) Text('• $t'),
+                  ],
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('OK'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   Future<void> _next() async {
     if (_selectedIndices.isEmpty) return;
     final question = _questions[_current];
@@ -99,23 +143,7 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
     if (!correct) {
       final correctOptions =
           question.options.where((o) => o.isCorrect).map((o) => o.text).toList();
-      await showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Bonne(s) réponse(s)'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [for (final t in correctOptions) Text('• ' + t)],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
+      await _showWrongAnswerDialog(correctOptions);
       if (!mounted) return;
     }
 

--- a/lib/screens/quiz_stats_screen.dart
+++ b/lib/screens/quiz_stats_screen.dart
@@ -105,7 +105,14 @@ class _QuizStatsScreenState extends State<QuizStatsScreen> {
                   style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 4),
-                LinearProgressIndicator(value: percent),
+                TweenAnimationBuilder<double>(
+                  duration: const Duration(milliseconds: 500),
+                  curve: Curves.easeOut,
+                  tween: Tween(begin: 0.0, end: percent),
+                  builder: (context, value, child) {
+                    return LinearProgressIndicator(value: value);
+                  },
+                ),
                 const SizedBox(height: 4),
                 Text(
                   '${e.value.correct} / ${e.value.answered} bonnes réponses ($percentText\u202f%)',


### PR DESCRIPTION
## Summary
- add animated dialog for wrong quiz answers
- animate progress bars on the statistics page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a708f86f4832d813980452363a252