### PR TITLE
Gère proprement les contrôleurs des champs d’infractions

### DIFF
--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -11,7 +11,7 @@ class RechercheInfractionQuizScreen extends StatefulWidget {
 }
 
 class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizScreen> {
-  final List<TextEditingController> _controllers = [TextEditingController()];
+  final List<TextEditingController?> _controllers = [];
   late Future<List<String>> _suggestions;
 
   @override
@@ -23,20 +23,21 @@ class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizS
   @override
   void dispose() {
     for (final c in _controllers) {
-      c.dispose();
+      c?.dispose();
     }
     super.dispose();
   }
 
   void _addField() {
     setState(() {
-      _controllers.add(TextEditingController());
+      _controllers.add(null);
     });
   }
 
   Future<void> _validate() async {
     final expected = widget.caseData.infractions.map((e) => e.toLowerCase()).toSet();
     final provided = _controllers
+        .whereType<TextEditingController>()
         .map((c) => c.text.trim().toLowerCase())
         .where((e) => e.isNotEmpty)
         .toSet();
@@ -64,8 +65,15 @@ class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizS
           return suggestions.where((s) => s.toLowerCase().contains(text.text.toLowerCase()));
         },
         fieldViewBuilder: (_, controller, focusNode, onFieldSubmitted) {
-          _controllers[index] = controller;
-          return TextField(controller: controller, focusNode: focusNode, onSubmitted: (_) => onFieldSubmitted());
+          if (_controllers[index] == null) {
+            _controllers[index] = controller;
+          } else {
+            controller = _controllers[index]!;
+          }
+          return TextField(
+              controller: controller,
+              focusNode: focusNode,
+              onSubmitted: (_) => onFieldSubmitted());
         },
       ),
     );


### PR DESCRIPTION
## Résumé
- initialiser la liste de contrôleurs à vide
- ajouter `null` lors de l’ajout d’un champ
- utiliser ou créer le contrôleur dans `fieldViewBuilder`
- ignorer les valeurs nulles lors de la validation
- fermer tous les contrôleurs existants dans `dispose`

## Tests
- `flutter analyze` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688be50af708832d864a2858943e9e9c