### PR TITLE
Déplacement du bouton moderne et refonte du menu quiz

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'cadre_list_screen.dart';
 import 'search_screen.dart';
 import 'quiz_menu_screen.dart';
 import '../widgets/ad_banner.dart';
+import '../widgets/modern_gradient_button.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -38,7 +39,7 @@ class HomeScreen extends StatelessWidget {
                     children: [
                       FractionallySizedBox(
                         widthFactor: 0.85,
-                        child: _ModernGradientButton(
+                        child: ModernGradientButton(
                           icon: Icons.book,
                           label: 'Infractions par thèmes',
                   onPressed: () {
@@ -56,7 +57,7 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 16),
               FractionallySizedBox(
                 widthFactor: 0.85,
-                child: _ModernGradientButton(
+                child: ModernGradientButton(
                   icon: Icons.gavel,
                   label: "Cadres d'enquête",
                   onPressed: () {
@@ -74,7 +75,7 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 16),
               FractionallySizedBox(
                 widthFactor: 0.85,
-                child: _ModernGradientButton(
+                child: ModernGradientButton(
                   icon: Icons.search,
                   label: "Rechercher une infraction",
                   onPressed: () {
@@ -92,7 +93,7 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 16),
               FractionallySizedBox(
                 widthFactor: 0.85,
-                child: _ModernGradientButton(
+                child: ModernGradientButton(
                   icon: Icons.star,
                   label: 'Mes favoris',
                   onPressed: () {
@@ -110,7 +111,7 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 16),
               FractionallySizedBox(
                 widthFactor: 0.85,
-                child: _ModernGradientButton(
+                child: ModernGradientButton(
                   icon: Icons.quiz,
                   label: 'Quiz',
                   onPressed: () {
@@ -128,98 +129,6 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 32),
               const AdBanner(),
             ],
-          ),
-        ),
-      ),
-    ],
-    ),
-    ),
-      )
-      );
-  }
-}
-
-// Widget bouton moderne avec dégradé subtil, coins peu arrondis, effet hover/clic
-class _ModernGradientButton extends StatefulWidget {
-  final IconData icon;
-  final String label;
-  final VoidCallback onPressed;
-  const _ModernGradientButton({
-    required this.icon,
-    required this.label,
-    required this.onPressed,
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  State<_ModernGradientButton> createState() => _ModernGradientButtonState();
-}
-
-class _ModernGradientButtonState extends State<_ModernGradientButton> {
-  bool _hovering = false;
-  bool _pressed = false;
-
-  void _setHover(bool value) {
-    setState(() {
-      _hovering = value;
-    });
-  }
-
-  void _setPressed(bool value) {
-    setState(() {
-      _pressed = value;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    double opacity = 1.0;
-    if (_pressed) {
-      opacity = 0.82;
-    } else if (_hovering) {
-      opacity = 0.90;
-    }
-    return MouseRegion(
-      onEnter: (_) => _setHover(true),
-      onExit: (_) => _setHover(false),
-      child: GestureDetector(
-        onTapDown: (_) => _setPressed(true),
-        onTapUp: (_) => _setPressed(false),
-        onTapCancel: () => _setPressed(false),
-        child: AnimatedOpacity(
-          duration: const Duration(milliseconds: 120),
-          opacity: opacity,
-          child: Container(
-            decoration: BoxDecoration(
-              gradient: const LinearGradient(
-                colors: [Color(0xFFFAF9F6), Colors.white,Color(0xFFFAF9F6)],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              ),
-              borderRadius: BorderRadius.circular(8),
-              boxShadow: const [
-                BoxShadow(
-                  color: Colors.black26,
-                  blurRadius: 8,
-                  offset: Offset(0, 4),
-                ),
-              ],
-            ),
-            child: ElevatedButton.icon(
-              icon: Icon(widget.icon),
-              label: Text(widget.label),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.transparent,
-                shadowColor: Colors.transparent,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-                textStyle: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-                elevation: 0,
-              ),
-              onPressed: widget.onPressed,
-            ),
           ),
         ),
       ),

--- a/lib/screens/quiz_menu_screen.dart
+++ b/lib/screens/quiz_menu_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import '../widgets/ad_banner.dart';
+import '../widgets/modern_gradient_button.dart';
 import 'quiz_cadre_screen.dart';
 import 'quiz_stats_screen.dart';
 import 'recherche/recherche_infraction_list_screen.dart';
@@ -13,64 +15,88 @@ class QuizMenuScreen extends StatelessWidget {
       appBar: AppBar(
         title: const AdaptiveAppBarTitle('Quiz', maxLines: 1),
       ),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SizedBox(
-              width: 220,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => const QuizCadreScreen(),
-                    ),
-                  );
-                },
-                child: const Text('Quiz cadres d\'enquête'),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF001F4D), Color(0xFF122046)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Expanded(
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.gavel,
+                          label: "Quiz cadres d'enquête",
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => const QuizCadreScreen(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.help_outline,
+                          label: 'Quiz infractions',
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('À venir')),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.search,
+                          label: 'Recherche d\u2019infractions',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) =>
+                                    const RechercheInfractionListScreen(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.bar_chart,
+                          label: 'Statistiques',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => const QuizStatsScreen(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ),
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: 220,
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('À venir')),
-                  );
-                },
-                child: const Text('Quiz infractions'),
-              ),
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: 220,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => const RechercheInfractionListScreen(),
-                    ),
-                  );
-                },
-                child: const Text('Recherche d\u2019infractions'),
-              ),
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: 220,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => const QuizStatsScreen(),
-                    ),
-                  );
-                },
-                child: const Text('Statistiques'),
-              ),
-            ),
-          ],
+              const SizedBox(height: 32),
+              const AdBanner(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/modern_gradient_button.dart
+++ b/lib/widgets/modern_gradient_button.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+/// Bouton moderne avec dégradé subtil et légère animation de survol.
+class ModernGradientButton extends StatefulWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+  const ModernGradientButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<ModernGradientButton> createState() => _ModernGradientButtonState();
+}
+
+class _ModernGradientButtonState extends State<ModernGradientButton> {
+  bool _hovering = false;
+  bool _pressed = false;
+
+  void _setHover(bool value) {
+    setState(() {
+      _hovering = value;
+    });
+  }
+
+  void _setPressed(bool value) {
+    setState(() {
+      _pressed = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    double opacity = 1.0;
+    if (_pressed) {
+      opacity = 0.82;
+    } else if (_hovering) {
+      opacity = 0.90;
+    }
+    return MouseRegion(
+      onEnter: (_) => _setHover(true),
+      onExit: (_) => _setHover(false),
+      child: GestureDetector(
+        onTapDown: (_) => _setPressed(true),
+        onTapUp: (_) => _setPressed(false),
+        onTapCancel: () => _setPressed(false),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 120),
+          opacity: opacity,
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                colors: [Color(0xFFFAF9F6), Colors.white, Color(0xFFFAF9F6)],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black26,
+                  blurRadius: 8,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: ElevatedButton.icon(
+              icon: Icon(widget.icon),
+              label: Text(widget.label),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.transparent,
+                shadowColor: Colors.transparent,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                textStyle: const TextStyle(
+                    fontSize: 18, fontWeight: FontWeight.w600),
+                elevation: 0,
+              ),
+              onPressed: widget.onPressed,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- extraction de `_ModernGradientButton` dans un nouveau fichier public `ModernGradientButton`
- mise à jour de `home_screen.dart` pour utiliser ce widget exporté
- refonte de `quiz_menu_screen.dart` avec un arrière‑plan dégradé, des boutons modernisés et ajout de la bannière pub

## Tests
- `flutter analyze` *(échoue : commande introuvable)*
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688c8b68e40c832da71dcb7f3c202055