### PR TITLE
Ajout de l'écran de menu Droit pénal spécial

### DIFF
--- a/lib/screens/droit_penal_special_menu_screen.dart
+++ b/lib/screens/droit_penal_special_menu_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'theme_screen.dart';
+import 'search_screen.dart';
+import 'favorites_screen.dart';
+import '../widgets/modern_gradient_button.dart';
+
+class DroitPenalSpecialMenuScreen extends StatelessWidget {
+  const DroitPenalSpecialMenuScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF001F4D), Color(0xFF122046)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FractionallySizedBox(
+                  widthFactor: 0.85,
+                  child: ModernGradientButton(
+                    icon: Icons.book,
+                    label: 'Infractions par thèmes',
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        PageRouteBuilder(
+                          pageBuilder: (_, animation, __) => FadeTransition(
+                            opacity: animation,
+                            child: const ThemeScreen(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+                FractionallySizedBox(
+                  widthFactor: 0.85,
+                  child: ModernGradientButton(
+                    icon: Icons.search,
+                    label: 'Rechercher une infraction',
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        PageRouteBuilder(
+                          pageBuilder: (_, animation, __) => FadeTransition(
+                            opacity: animation,
+                            child: const SearchScreen(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+                FractionallySizedBox(
+                  widthFactor: 0.85,
+                  child: ModernGradientButton(
+                    icon: Icons.star,
+                    label: 'Mes favoris',
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        PageRouteBuilder(
+                          pageBuilder: (_, animation, __) => FadeTransition(
+                            opacity: animation,
+                            child: const FavoritesScreen(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Résumé
- ajout de l'écran `DroitPenalSpecialMenuScreen` avec un fond dégradé cohérent
- intégration de trois `ModernGradientButton` menant vers les écrans Thèmes, Recherche et Favoris

## Tests
- `flutter test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6890aa328200832d95da150fc31653b2