### PR TITLE
Refactorise l'écran d'accueil avec de nouveaux menus

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'theme_screen.dart';
-import 'favorites_screen.dart';
-import 'cadre_list_screen.dart';
-import 'search_screen.dart';
+import 'droit_penal_special_menu_screen.dart';
+import 'procedure_penale_menu_screen.dart';
 import 'quiz_menu_screen.dart';
 import '../widgets/ad_banner.dart';
 import '../widgets/modern_gradient_button.dart';
@@ -40,92 +38,56 @@ class HomeScreen extends StatelessWidget {
                       FractionallySizedBox(
                         widthFactor: 0.85,
                         child: ModernGradientButton(
-                          icon: Icons.book,
-                          label: 'Infractions par thèmes',
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      PageRouteBuilder(
-                        pageBuilder: (_, animation, __) => FadeTransition(
-                          opacity: animation,
-                          child: const ThemeScreen(),
+                          icon: Icons.gavel,
+                          label: 'Droit Pénal Spécial',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              PageRouteBuilder(
+                                pageBuilder: (_, animation, __) => FadeTransition(
+                                  opacity: animation,
+                                  child: const DroitPenalSpecialMenuScreen(),
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
-                    );
-                  },
-                ),
-              ),
-              const SizedBox(height: 16),
-              FractionallySizedBox(
-                widthFactor: 0.85,
-                child: ModernGradientButton(
-                  icon: Icons.gavel,
-                  label: "Cadres d'enquête",
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      PageRouteBuilder(
-                        pageBuilder: (_, animation, __) => FadeTransition(
-                          opacity: animation,
-                          child: const CadreListScreen(),
+                      const SizedBox(height: 16),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.account_balance,
+                          label: 'Procédure Pénale',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              PageRouteBuilder(
+                                pageBuilder: (_, animation, __) => FadeTransition(
+                                  opacity: animation,
+                                  child: const ProcedurePenaleMenuScreen(),
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
-                    );
-                  },
-                ),
-              ),
-              const SizedBox(height: 16),
-              FractionallySizedBox(
-                widthFactor: 0.85,
-                child: ModernGradientButton(
-                  icon: Icons.search,
-                  label: "Rechercher une infraction",
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      PageRouteBuilder(
-                        pageBuilder: (_, animation, __) => FadeTransition(
-                          opacity: animation,
-                          child: const SearchScreen(),
+                      const SizedBox(height: 16),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.quiz,
+                          label: 'S’entrainer',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              PageRouteBuilder(
+                                pageBuilder: (_, animation, __) => FadeTransition(
+                                  opacity: animation,
+                                  child: const QuizMenuScreen(),
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
-                    );
-                  },
-                ),
-              ),
-              const SizedBox(height: 16),
-              FractionallySizedBox(
-                widthFactor: 0.85,
-                child: ModernGradientButton(
-                  icon: Icons.star,
-                  label: 'Mes favoris',
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      PageRouteBuilder(
-                        pageBuilder: (_, animation, __) => FadeTransition(
-                          opacity: animation,
-                          child: const FavoritesScreen(),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
-              const SizedBox(height: 16),
-              FractionallySizedBox(
-                widthFactor: 0.85,
-                child: ModernGradientButton(
-                  icon: Icons.quiz,
-                  label: 'Quiz',
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      PageRouteBuilder(
-                        pageBuilder: (_, animation, __) => FadeTransition(
-                          opacity: animation,
-                          child: const QuizMenuScreen(),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
                     ],
                   ),
                 ),

--- a/lib/screens/procedure_penale_menu_screen.dart
+++ b/lib/screens/procedure_penale_menu_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class ProcedurePenaleMenuScreen extends StatelessWidget {
+  const ProcedurePenaleMenuScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF001F4D), Color(0xFF122046)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: const SafeArea(
+          child: Center(
+            child: Text(
+              'Procédure Pénale',
+              style: TextStyle(color: Colors.white, fontSize: 24),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Résumé
- remplace les anciens boutons par des accès vers le droit pénal spécial, la procédure pénale et l’entraînement
- ajoute un écran de menu pour la procédure pénale

## Tests
- `flutter test` *(échec : commande introuvable)*
- tentative `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad587100832d9a81c239c0a76ea6