### PR TITLE
Remplacer le libellé Quiz sur l'écran d'accueil

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -113,7 +113,7 @@ class HomeScreen extends StatelessWidget {
                 widthFactor: 0.85,
                 child: ModernGradientButton(
                   icon: Icons.quiz,
-                  label: 'Quiz',
+                  label: 'S’entrainer',
                   onPressed: () {
                     Navigator.of(context).push(
                       PageRouteBuilder(


### PR DESCRIPTION
## Résumé
- renomme le bouton "Quiz" en "S’entrainer" sur l'écran d'accueil

## Test
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad5cc7f4832dbdb688467ba38cd3