### PR TITLE
Corrige la fermeture de la colonne dans HomeScreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -70,8 +70,8 @@ class HomeScreen extends StatelessWidget {
                           },
                         ),
                       ),
-                    );
-                  },
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: 16),


### PR DESCRIPTION
## Résumé
- Corrige la clôture de la liste `children` dans `HomeScreen`
- Ferme correctement la `Column` interne, le `Center` et l'`Expanded`

## Test
- `flutter test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b1a46314832d97b334d01460a25b