### PR TITLE
Ajoute un quiz PP supplémentaire

### DIFF
--- a/assets/data/quiz_pp.json
+++ b/assets/data/quiz_pp.json
@@ -1,0 +1,2128 @@
+[
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14",
+        "is_correct": true
+      },
+      {
+        "text": "75 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "55 CPP (crime)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Audition de témoin",
+    "propositions": [
+      {
+        "text": "78 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "706-58 CPP (anonymat)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Audition de victime",
+    "propositions": [
+      {
+        "text": "78 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "10-2 à 10-6 et 15-3 CPP (uniquement pour majeur)",
+        "is_correct": true
+      },
+      {
+        "text": "706-52",
+        "is_correct": true
+      },
+      {
+        "text": "706-53 CPP (mineur victime infraction prévue par l’art. 706-47 CPP)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Audition libre de mis en cause",
+    "propositions": [
+      {
+        "text": "77 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "L412-1 et L412-2 du CJPM (mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Garde à vue, Retenue judiciaire",
+    "propositions": [
+      {
+        "text": "77 DU CPP",
+        "is_correct": true
+      },
+      {
+        "text": "L413-6 à L413-11 du CJPM (mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-1 à L413-5 du CJPM (retenue)",
+        "is_correct": true
+      },
+      {
+        "text": "78 CPP (contrainte force publique - PR)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "77-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Réquisition aux fins de remise d'informations",
+    "propositions": [
+      {
+        "text": "77-1-1",
+        "is_correct": true
+      },
+      {
+        "text": "77-1-2 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Réquisition d’interception (com. electroniques)",
+    "propositions": [
+      {
+        "text": "706-95  CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Perquisition",
+    "propositions": [
+      {
+        "text": "76 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "76-3 CPP (données informatique)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "perquisition en dehors des heures légales",
+    "propositions": [
+      {
+        "text": "706-90  CPP (criminalité et délinquance organisées)",
+        "is_correct": true
+      },
+      {
+        "text": "706-28 CPP (Trafic de produits stupéfiants",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "706-35 CPP (Traite des êtres humains",
+        "is_correct": true
+      },
+      {
+        "text": "Proxénétisme ou recours à la prostitution des mineurs",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Saisie",
+    "propositions": [
+      {
+        "text": "76",
+        "is_correct": true
+      },
+      {
+        "text": "CPP",
+        "is_correct": true
+      },
+      {
+        "text": "76-3 CPP (accès à des données dans un système\ninformatique)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Bris de scellé ",
+    "propositions": [
+      {
+        "text": "41-4 CPP (restitution)",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Assistance autopsie ",
+    "propositions": [
+      {
+        "text": "230-28 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Investigation",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Transcription d’une interception com.",
+    "propositions": [
+      {
+        "text": "100 à 100-8 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE PRÉLIMINAIRE",
+    "acte": "Procès-verbal d’interpellation ",
+    "propositions": [
+      {
+        "text": "73 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14",
+        "is_correct": true
+      },
+      {
+        "text": "54",
+        "is_correct": true
+      },
+      {
+        "text": "CPP",
+        "is_correct": true
+      },
+      {
+        "text": "55 CPP (crime)",
+        "is_correct": true
+      },
+      {
+        "text": "67 (délit)",
+        "is_correct": true
+      },
+      {
+        "text": "61",
+        "is_correct": true
+      },
+      {
+        "text": "al. 1 (défendre de s'éloigner)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Audition de témoin",
+    "propositions": [
+      {
+        "text": "61",
+        "is_correct": true
+      },
+      {
+        "text": "62 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "706-58 CPP (anonymat)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "audition de témoin\nd’un représentant légal d’un mineur auteur",
+    "propositions": [
+      {
+        "text": "L412-1 et L412-2 CPP (libre)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-3",
+        "is_correct": true
+      },
+      {
+        "text": "L413-5 CPP (retenue)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-7",
+        "is_correct": true
+      },
+      {
+        "text": "L413-8",
+        "is_correct": true
+      },
+      {
+        "text": "L413-9 CJPM (GAV mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Audition victime (ou représentant légal mineur",
+    "propositions": [
+      {
+        "text": "61",
+        "is_correct": true
+      },
+      {
+        "text": "62 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "10-2 à 10-6 et 15-3 CPP (majeur)",
+        "is_correct": true
+      },
+      {
+        "text": "706-52",
+        "is_correct": true
+      },
+      {
+        "text": "706-53 CPP (mineur victime infraction prévue par l’art. 706-47 CPP)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Audition libre de mis en cause",
+    "propositions": [
+      {
+        "text": "61-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "L412-1 et L412-2 CJPM (mineur GAV)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Garde à vue, Retenue judiciaire",
+    "propositions": [
+      {
+        "text": "62-2 à 64 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "L413-6 à L413-11 CJPM (mineur GAV)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-1 à L413-5 CJPM (retenue)",
+        "is_correct": true
+      },
+      {
+        "text": "prolongation (infraction prévue art.706-73) : 706-88 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition à prestataire de service",
+    "propositions": [
+      {
+        "text": "R. 642-1 du CP",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 du CPP (réquisition témoins perquisition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "60 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "60-3 CPP (ouverture de scellé d'un objet qui est le support de données informatiques)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition aux fins de remise d'informations + gel données",
+    "propositions": [
+      {
+        "text": "60-1 / 60-2 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition géolocalisation (hors cas exclus par l’art. 230-44)",
+    "propositions": [
+      {
+        "text": "230-32 à 230-44 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition autorité militaire ",
+    "propositions": [
+      {
+        "text": "698-3 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Réquisition d’interception (correspondances émises par la voie des communications électroniques)",
+    "propositions": [
+      {
+        "text": "706-95 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Perquisition ",
+    "propositions": [
+      {
+        "text": "56",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "58 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "59 CPP (domicile)",
+        "is_correct": true
+      },
+      {
+        "text": "57-1 CPP (accès à des données dans un système\ninformatique)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Perquisition hros heure légale",
+    "propositions": [
+      {
+        "text": "59-1  CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-89 CPP (criminalité et délinquance organisées)",
+        "is_correct": true
+      },
+      {
+        "text": "706-28 (Trafic de produits stupéfiants",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "706-35 (Traite des êtres humains",
+        "is_correct": true
+      },
+      {
+        "text": "Proxénétisme ou recours à la prostitution des mineurs",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Saisie,",
+    "propositions": [
+      {
+        "text": "76 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "76-3 CPP (accès à des données dans un système\ninformatique)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Bris de scellé ,",
+    "propositions": [
+      {
+        "text": "41-4 CPP (restitution)",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Assistance autopsie ",
+    "propositions": [
+      {
+        "text": "230-28 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Investigation ",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Transcription d’une interception (correspondances émises par la voie des communications électroniques) ",
+    "propositions": [
+      {
+        "text": "100 à 100-8 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "ENQUÊTE DE FLAGRANCE",
+    "acte": "Procès-verbal d’interpellation",
+    "propositions": [
+      {
+        "text": "73 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "41-5 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14",
+        "is_correct": true
+      },
+      {
+        "text": "152  CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Audition de témoin",
+    "propositions": [
+      {
+        "text": "103",
+        "is_correct": true
+      },
+      {
+        "text": "153 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "706-58 CPP (anonymat)",
+        "is_correct": true
+      },
+      {
+        "text": "108 (mineur de 16 ans)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "audition de témoin\nd’un représentant légal d’un mineur auteur",
+    "propositions": [
+      {
+        "text": "L412-1 et L412-2 CPP (libre)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-3",
+        "is_correct": true
+      },
+      {
+        "text": "L413-5 CPP (retenue)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-7",
+        "is_correct": true
+      },
+      {
+        "text": "L413-8",
+        "is_correct": true
+      },
+      {
+        "text": "L413-9 CJPM (GAV mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Audition victime ",
+    "propositions": [
+      {
+        "text": "103",
+        "is_correct": true
+      },
+      {
+        "text": "153 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "10-2 à 10-6 CPP (majeur)",
+        "is_correct": true
+      },
+      {
+        "text": "152",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 (partie civile)",
+        "is_correct": true
+      },
+      {
+        "text": "108 (mineur de 16 ans)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Audition libre de mis en cause",
+    "propositions": [
+      {
+        "text": "154 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "L412-1 et L412-2 du CJPM (mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Garde à vue, Retenue judiciaire",
+    "propositions": [
+      {
+        "text": "153",
+        "is_correct": true
+      },
+      {
+        "text": "al.3",
+        "is_correct": true
+      },
+      {
+        "text": "154 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "105 CPP (indices graves et concordants)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-1 à L413-5 CJPM (retenue)",
+        "is_correct": true
+      },
+      {
+        "text": "L413-6 à L413-11 du CJPM (GAV mineur)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition à prestataire de service",
+    "propositions": [
+      {
+        "text": "R. 642-1 du CP",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 du CPP (réquisition témoins perquisition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "81 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "99-5 CP (ouverture de scellé d'un objet qui est le\nsupport\nde données informatiques)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition aux fins de remise d'informations + gel données",
+    "propositions": [
+      {
+        "text": "99-3 / 99-4 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition géolocalisation (hors cas exclus par l’art. 230-44)",
+    "propositions": [
+      {
+        "text": "230-32 à 230-44 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition autorité militaire ",
+    "propositions": [
+      {
+        "text": "698-3 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Réquisition d’interception (correspondances émises par la voie des communications électroniques)",
+    "propositions": [
+      {
+        "text": "100 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "80-4 CPP (pour recherche des causes de la mort\nou des causes d’une disparition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Perquisition ",
+    "propositions": [
+      {
+        "text": "94",
+        "is_correct": true
+      },
+      {
+        "text": "97",
+        "is_correct": true
+      },
+      {
+        "text": "98 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "95 CPP (domicile MEE)",
+        "is_correct": true
+      },
+      {
+        "text": "96 CPP (hors domicile MEE)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Perquisition hors heure légale",
+    "propositions": [
+      {
+        "text": "97-2 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-91 CPP (criminalité et délinquance organisées)",
+        "is_correct": true
+      },
+      {
+        "text": "706-28 (Trafic de produits stupéfiants",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "706-35 (Traite des êtres humains",
+        "is_correct": true
+      },
+      {
+        "text": "Proxénétisme ou recours à la prostitution des mineurs",
+        "is_correct": true
+      },
+      {
+        "text": "participation à une association de malfaiteurs)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Saisie,",
+    "propositions": [
+      {
+        "text": "94",
+        "is_correct": true
+      },
+      {
+        "text": "97",
+        "is_correct": true
+      },
+      {
+        "text": "98 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "95 CPP (domicile MEE)",
+        "is_correct": true
+      },
+      {
+        "text": "96 (hors domicile MEE)",
+        "is_correct": true
+      },
+      {
+        "text": "97-1 CPP (accès à des données dans un système\ninformatique)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Bris de scellé ,",
+    "propositions": [
+      {
+        "text": "99 CPP (restitution)",
+        "is_correct": true
+      },
+      {
+        "text": "99-2 CPP (destruction)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Assistance autopsie ",
+    "propositions": [
+      {
+        "text": "230-28 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Investigation ",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Transcription d’une interception (correspondances émises par la voie des communications électroniques) ",
+    "propositions": [
+      {
+        "text": "100 à 100-8 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "COMMISSION ROGATOIRE",
+    "acte": "Procès-verbal d’interpellation",
+    "propositions": [
+      {
+        "text": "73 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 1 (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Audition de témoin",
+    "propositions": [
+      {
+        "text": "103",
+        "is_correct": true
+      },
+      {
+        "text": "153 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "706-58 CPP (anonymat)",
+        "is_correct": true
+      },
+      {
+        "text": "108 (mineur de 16 ans)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Audition victime ",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (Uniquement DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "10-2 à 10-6 et 15-3 CPP (uniquement pour\nmajeur",
+        "is_correct": true
+      },
+      {
+        "text": "DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Réquisition à prestataire de service",
+    "propositions": [
+      {
+        "text": "R. 642-1 du CP",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 du CPP (réquisition témoins perquisition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 4 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Réquisition aux fins de remise d'informations + gel données",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 4 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Réquisition géolocalisation (hors cas exclus par l’art. 230-44)",
+    "propositions": [
+      {
+        "text": "230-32 à 230-44 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Réquisition autorité militaire ",
+    "propositions": [
+      {
+        "text": "698-3 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Perquisition ",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 4 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Saisie,",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 4 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Bris de scellé ,",
+    "propositions": [
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 4 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74",
+        "is_correct": true
+      },
+      {
+        "text": "al. 6 CPP (DPGB)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Assistance autopsie ",
+    "propositions": [
+      {
+        "text": "230-28 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DÉCOUVERTE DE CADAVRE\nOU DE PERSONNE GRIÈVEMENT\nBLESSÉE",
+    "acte": "Investigation ",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14",
+        "is_correct": true
+      },
+      {
+        "text": "74-1  CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Réquisition à prestataire de service",
+    "propositions": [
+      {
+        "text": "R. 642-1 du CP",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 du CPP (réquisition témoins perquisition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "74-1 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Réquisition aux fins de remise d'informations + gel données",
+    "propositions": [
+      {
+        "text": "74-1",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Réquisition géolocalisation (hors cas exclus par l’art. 230-44)",
+    "propositions": [
+      {
+        "text": "230-32 à 230-44 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Réquisition autorité militaire ",
+    "propositions": [
+      {
+        "text": "698-3 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Perquisition ",
+    "propositions": [
+      {
+        "text": "74-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Saisie et bris de scellé,",
+    "propositions": [
+      {
+        "text": "74-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "DISPARITION INQUIÉTANTE",
+    "acte": "Investigation ",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Transport, Constatations et Mesures Prises",
+    "propositions": [
+      {
+        "text": "14",
+        "is_correct": true
+      },
+      {
+        "text": "74-2  CPP",
+        "is_correct": true
+      },
+      {
+        "text": "706-57 CPP (changement domiciliation)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Réquisition à prestataire de service",
+    "propositions": [
+      {
+        "text": "R. 642-1 du CP",
+        "is_correct": true
+      },
+      {
+        "text": "57",
+        "is_correct": true
+      },
+      {
+        "text": "al. 2 du CPP (réquisition témoins perquisition)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Réquisition personne qualifiée",
+    "propositions": [
+      {
+        "text": "74-1 CPP (DC)",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Réquisition aux fins de remise d'informations + gel données",
+    "propositions": [
+      {
+        "text": "74-1",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Réquisition géolocalisation (hors cas exclus par l’art. 230-44)",
+    "propositions": [
+      {
+        "text": "230-32 à 230-44 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Réquisition autorité militaire ",
+    "propositions": [
+      {
+        "text": "698-3 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Perquisition ",
+    "propositions": [
+      {
+        "text": "74-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Saisie et bris de scellé,",
+    "propositions": [
+      {
+        "text": "74-1 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  },
+  {
+    "cadre": "RECHERCHEDE PERSONNE EN FUITE",
+    "acte": "Investigation ",
+    "propositions": [
+      {
+        "text": "17 CPP",
+        "is_correct": true
+      },
+      {
+        "text": "74 CPP",
+        "is_correct": false
+      },
+      {
+        "text": "76 CPP",
+        "is_correct": false
+      }
+    ]
+  }
+]

--- a/lib/models/quiz_pp_question.dart
+++ b/lib/models/quiz_pp_question.dart
@@ -1,0 +1,28 @@
+import 'quiz_question.dart';
+
+class QuizPPQuestion {
+  final String cadre;
+  final String acte;
+  final List<QuizOption> propositions;
+
+  QuizPPQuestion({required this.cadre, required this.acte, required this.propositions});
+
+  factory QuizPPQuestion.fromJson(Map<String, dynamic> json) => QuizPPQuestion(
+        cadre: json['cadre'] ?? '',
+        acte: json['acte'] ?? '',
+        propositions: (json['propositions'] as List? ?? [])
+            .whereType<Map>()
+            .map((e) => QuizOption.fromJson(e.cast<String, dynamic>()))
+            .toList(),
+      );
+
+  Set<int> get correctIndices => {
+        for (var i = 0; i < propositions.length; i++)
+          if (propositions[i].isCorrect) i
+      };
+
+  bool isCorrectSet(Set<int> selection) {
+    final correct = correctIndices;
+    return selection.length == correct.length && selection.containsAll(correct);
+  }
+}

--- a/lib/screens/quiz_menu_screen.dart
+++ b/lib/screens/quiz_menu_screen.dart
@@ -3,6 +3,7 @@ import '../widgets/adaptive_appbar_title.dart';
 import '../widgets/ad_banner.dart';
 import '../widgets/modern_gradient_button.dart';
 import 'quiz_cadre_screen.dart';
+import 'quiz_pp_screen.dart';
 import 'quiz_stats_screen.dart';
 import 'recherche/recherche_infraction_list_screen.dart';
 
@@ -31,42 +32,57 @@ class QuizMenuScreen extends StatelessWidget {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      FractionallySizedBox(
-                        widthFactor: 0.85,
-                        child: ModernGradientButton(
-                          icon: Icons.gavel,
-                          label: "Quiz cadres d'enquête",
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (_) => const QuizCadreScreen(),
-                              ),
-                            );
-                          },
+                        FractionallySizedBox(
+                          widthFactor: 0.85,
+                          child: ModernGradientButton(
+                            icon: Icons.gavel,
+                            label: "Quiz cadres d'enquête",
+                            onPressed: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const QuizCadreScreen(),
+                                ),
+                              );
+                            },
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 16),
-                      FractionallySizedBox(
-                        widthFactor: 0.85,
-                        child: ModernGradientButton(
-                          icon: Icons.help_outline,
-                          label: 'Quiz infractions',
-                          onPressed: () {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('À venir')),
-                            );
-                          },
+                        const SizedBox(height: 16),
+                        FractionallySizedBox(
+                          widthFactor: 0.85,
+                          child: ModernGradientButton(
+                            icon: Icons.school,
+                            label: 'Quiz PP',
+                            onPressed: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const QuizPPScreen(),
+                                ),
+                              );
+                            },
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 16),
-                      FractionallySizedBox(
-                        widthFactor: 0.85,
-                        child: ModernGradientButton(
-                          icon: Icons.search,
-                          label: 'Recherche d\u2019infractions',
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
+                        const SizedBox(height: 16),
+                        FractionallySizedBox(
+                          widthFactor: 0.85,
+                          child: ModernGradientButton(
+                            icon: Icons.help_outline,
+                            label: 'Quiz infractions',
+                            onPressed: () {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('À venir')),
+                              );
+                            },
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        FractionallySizedBox(
+                          widthFactor: 0.85,
+                          child: ModernGradientButton(
+                            icon: Icons.search,
+                            label: 'Recherche d’infractions',
+                            onPressed: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
                                 builder: (_) =>
                                     const RechercheInfractionListScreen(),
                               ),

--- a/lib/screens/quiz_pp_screen.dart
+++ b/lib/screens/quiz_pp_screen.dart
@@ -1,0 +1,232 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../models/quiz_pp_question.dart';
+import '../utils/json_loader.dart';
+import '../utils/quiz_progress_manager.dart';
+import '../widgets/adaptive_appbar_title.dart';
+
+class QuizPPScreen extends StatefulWidget {
+  const QuizPPScreen({super.key});
+
+  @override
+  State<QuizPPScreen> createState() => _QuizPPScreenState();
+}
+
+class _QuizPPScreenState extends State<QuizPPScreen> {
+  List<QuizPPQuestion> _questions = [];
+  int _current = 0;
+  int _score = 0;
+  Set<int> _selectedIndices = {};
+  bool _loading = true;
+  bool _finished = false;
+  Color? _feedbackColor;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadQuestions();
+  }
+
+  Future<void> _loadQuestions() async {
+    final data = await loadJsonWithComments('assets/data/quiz_pp.json');
+    final List<dynamic> list = json.decode(data);
+    setState(() {
+      final questions = list
+          .whereType<Map>()
+          .map((e) => QuizPPQuestion.fromJson(e.cast<String, dynamic>()))
+          .toList()
+        ..shuffle();
+      _questions = questions.length > 12 ? questions.take(12).toList() : questions;
+      _loading = false;
+    });
+  }
+
+  Widget _buildQuestion(QuizPPQuestion question) {
+    return Column(
+      key: ValueKey(_current),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Cadre : ${question.cadre}',
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Acte : ${question.acte}',
+          style: const TextStyle(fontSize: 16),
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: ListView.builder(
+            itemCount: question.propositions.length,
+            itemBuilder: (context, index) {
+              final opt = question.propositions[index];
+              return Card(
+                margin: const EdgeInsets.symmetric(vertical: 4),
+                child: CheckboxListTile(
+                  value: _selectedIndices.contains(index),
+                  onChanged: (v) {
+                    setState(() {
+                      if (v == true) {
+                        _selectedIndices.add(index);
+                      } else {
+                        _selectedIndices.remove(index);
+                      }
+                    });
+                  },
+                  title: Text(opt.text),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showWrongAnswerDialog(List<String> correctOptions) async {
+    await showGeneralDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      barrierColor: Colors.black54,
+      transitionDuration: const Duration(milliseconds: 300),
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Center(
+          child: Material(
+            type: MaterialType.transparency,
+            child: ScaleTransition(
+              scale: CurvedAnimation(parent: animation, curve: Curves.easeOutBack),
+              child: AlertDialog(
+                title: Row(
+                  children: const [
+                    Icon(Icons.close, color: Colors.red),
+                    SizedBox(width: 8),
+                    Expanded(child: Text('Bonne(s) réponse(s)')),
+                  ],
+                ),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 4),
+                    for (final t in correctOptions) Text('• $t'),
+                  ],
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('OK'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _next() async {
+    if (_selectedIndices.isEmpty) return;
+    final question = _questions[_current];
+    final correct = question.isCorrectSet(_selectedIndices);
+    if (correct) {
+      _score++;
+    }
+    await QuizProgressManager.recordQuestion(question.cadre, correct);
+
+    setState(() {
+      _feedbackColor = correct ? Colors.green : Colors.red;
+    });
+
+    await Future.delayed(const Duration(milliseconds: 300));
+    if (!mounted) return;
+
+    if (!correct) {
+      final correctOptions = question.propositions
+          .where((o) => o.isCorrect)
+          .map((o) => o.text)
+          .toList();
+      await _showWrongAnswerDialog(correctOptions);
+      if (!mounted) return;
+    }
+
+    setState(() {
+      _feedbackColor = null;
+      if (_current < _questions.length - 1) {
+        _current++;
+        _selectedIndices = {};
+      } else {
+        _finished = true;
+      }
+    });
+    if (_finished) {
+      await QuizProgressManager.incrementQuizCount();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const AdaptiveAppBarTitle('Quiz PP', maxLines: 1),
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_finished) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const AdaptiveAppBarTitle('Quiz PP', maxLines: 1),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Builder(
+                builder: (context) {
+                  final percent = (_score / _questions.length * 100).toStringAsFixed(1);
+                  return Text(
+                    'Score : $_score / ${_questions.length} ($percent\u202f%)',
+                    style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Fermer'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final question = _questions[_current];
+    return Scaffold(
+      appBar: AppBar(
+        title: const AdaptiveAppBarTitle('Quiz PP', maxLines: 1),
+      ),
+      body: Container(
+        color: _feedbackColor,
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: Padding(
+            key: ValueKey(_current),
+            padding: const EdgeInsets.all(16),
+            child: _buildQuestion(question),
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _next,
+        child: const Icon(Icons.check),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ flutter:
     - assets/data/cadres.json
     - assets/data/loader_test.json
     - assets/data/quiz_cadre_enquete.json
+    - assets/data/quiz_pp.json
     - assets/data/recherche_infractions.json
     - assets/images/
   #   - images/a_dot_ham.jpeg


### PR DESCRIPTION
## Résumé
- ajoute les données `quiz_pp.json` dérivées de `cadres.json`
- introduit le modèle `QuizPPQuestion` et l'écran `QuizPPScreen`
- déclare la ressource et ajoute un bouton vers ce quiz dans le menu d'entraînement

## Tests
- `flutter test` *(échoue: command not found)*
- `apt-get update` *(échoue: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890c34ce060832da080b53862040b99