### PR TITLE
Remplace les données de recherche par les exercices

### DIFF
--- a/lib/screens/recherche/recherche_infraction_list_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_list_screen.dart
@@ -25,7 +25,7 @@ class _RechercheInfractionListScreenState extends State<RechercheInfractionListS
   }
 
   Future<List<RechercheInfraction>> _loadCases() async {
-    final data = await loadJsonWithComments('assets/data/recherche_infractions.json');
+    final data = await loadJsonWithComments('assets/data/exercice_infractions.json');
     final List<dynamic> raw = json.decode(data) as List<dynamic>;
     return raw
         .whereType<Map<String, dynamic>>()

--- a/lib/utils/infraction_suggestions.dart
+++ b/lib/utils/infraction_suggestions.dart
@@ -1,12 +1,11 @@
 import 'dart:convert';
-import 'package:flutter/services.dart';
 import 'json_loader.dart';
 
 /// Charge et renvoie la liste des intitulés d'infractions disponibles dans
 /// l'application.
 ///
 /// Les suggestions sont extraites des fichiers `fiches.json` et
-/// `recherche_infractions.json` afin de couvrir intégralement les infractions
+/// `exercice_infractions.json` afin de couvrir intégralement les infractions
 /// présentes dans les histoires.
 Future<List<String>> loadInfractionSuggestions() async {
   final set = <String>{};
@@ -24,17 +23,16 @@ Future<List<String>> loadInfractionSuggestions() async {
     }
   }
 
-  // Suggestions provenant des scénarios de recherche d'infractions
-  final rechercheData =
-      await loadJsonWithComments('assets/data/recherche_infractions.json');
-  final List<dynamic> rechercheRaw = json.decode(rechercheData) as List<dynamic>;
-  for (final item in rechercheRaw) {
-    final corrections = (item as Map)['correction'] as List? ?? [];
-    for (final corr in corrections) {
-      final inf = (corr as Map)['infraction'] as Map? ?? {};
-      final qual = inf['qualification'];
-      if (qual is String && qual.trim().isNotEmpty) {
-        set.add(qual);
+  // Suggestions provenant des scénarios d'exercice d'infractions
+  final exerciceData =
+      await loadJsonWithComments('assets/data/exercice_infractions.json');
+  final List<dynamic> exerciceRaw = json.decode(exerciceData) as List<dynamic>;
+  for (final item in exerciceRaw) {
+    final infractions = (item as Map)['infractions_ciblees'] as List? ?? [];
+    for (final inf in infractions) {
+      final intitule = (inf as Map)['intitule'];
+      if (intitule is String && intitule.trim().isNotEmpty) {
+        set.add(intitule);
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,7 @@ flutter:
     - assets/data/loader_test.json
     - assets/data/quiz_cadre_enquete.json
     - assets/data/quiz_pp.json
-    - assets/data/recherche_infractions.json
+    - assets/data/exercice_infractions.json
     - assets/images/
   #   - images/a_dot_ham.jpeg
 

--- a/test/exercice_infractions_parsing_test.dart
+++ b/test/exercice_infractions_parsing_test.dart
@@ -6,9 +6,12 @@ import 'package:droitpenalspecial/models/recherche_infraction.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('chargement des cas depuis recherche_infractions.json', () async {
-    final data = await rootBundle.loadString('assets/data/recherche_infractions.json');
+  test('chargement des cas depuis exercice_infractions.json', () async {
+    final data =
+        await rootBundle.loadString('assets/data/exercice_infractions.json');
     final List<dynamic> list = json.decode(data) as List<dynamic>;
-    expect(() => list.map((e) => RechercheInfraction.fromJson(e)).toList(), returnsNormally);
+    expect(() => list.map((e) => RechercheInfraction.fromJson(e)).toList(),
+        returnsNormally);
   });
 }
+


### PR DESCRIPTION
## Résumé
- remplacement des données de recherche par les scénarios d'exercices
- collecte des intitulés dans les `infractions_ciblees`
- mise à jour du test de parsing associé

## Tests
- `flutter test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6892833c36f0832db7dbdee0abf7e258