### PR TITLE
Corrige le type de retour de _loadCases

### DIFF
--- a/lib/screens/recherche/recherche_infraction_list_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_list_screen.dart
@@ -25,7 +25,7 @@ class _RechercheInfractionListScreenState extends State<RechercheInfractionListS
   }
 
 
-  Future<List<RechercheInfraction>> _loadCases() async {
+  Future<List<ExerciceInfraction>> _loadCases() async {
     final data = await loadJsonWithComments('assets/data/exercice_infractions.json');
     final List<dynamic> raw = json.decode(data) as List<dynamic>;
     return raw


### PR DESCRIPTION
## Résumé
- Corrige la signature de `_loadCases` pour qu'elle retourne `Future<List<ExerciceInfraction>>`.

## Tests
- `flutter test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6893138f5afc832d852df6b17361e8e7