### PR TITLE
Affiche le titre et les détails de l'exercice

### DIFF
--- a/lib/screens/recherche/recherche_infraction_detail_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_detail_screen.dart
@@ -20,6 +20,11 @@ class RechercheInfractionDetailScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    Text(
+                      caseData.titre,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 16),
                     Text(caseData.contextualisation),
                     const SizedBox(height: 16),
                     Text(caseData.histoireDetaillee),


### PR DESCRIPTION
## Résumé
- Affichage du titre de l'exercice en tête du détail de recherche.
- Présentation structurée de la contextualisation et de l'histoire détaillée.

## Tests
- `flutter test` *(échoue : command not found)*
- `dart test` *(échoue : command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689313944698832d9e13ae39aed04156