### PR TITLE
Modernise recherche d'infractions et simplifie le menu de quiz

### DIFF
--- a/lib/screens/quiz_menu_screen.dart
+++ b/lib/screens/quiz_menu_screen.dart
@@ -49,19 +49,6 @@ class QuizMenuScreen extends StatelessWidget {
                       FractionallySizedBox(
                         widthFactor: 0.85,
                         child: ModernGradientButton(
-                          icon: Icons.help_outline,
-                          label: 'Quiz infractions',
-                          onPressed: () {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('À venir')),
-                            );
-                          },
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      FractionallySizedBox(
-                        widthFactor: 0.85,
-                        child: ModernGradientButton(
                           icon: Icons.search,
                           label: 'Recherche d’infractions',
                           onPressed: () {

--- a/lib/screens/recherche/recherche_infraction_correction_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_correction_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../../models/exercice_infraction.dart';
+
+class RechercheInfractionCorrectionScreen extends StatelessWidget {
+  final ExerciceInfraction caseData;
+  const RechercheInfractionCorrectionScreen({super.key, required this.caseData});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Correction')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: caseData.correction.length,
+        itemBuilder: (context, index) {
+          final corr = caseData.correction[index];
+          return Card(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Infraction ${corr.infractionNumero}: ${corr.qualification}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text('Personne concernée : ${corr.personneConcernee}'),
+                  Text('Articles : ${corr.articles}'),
+                  const SizedBox(height: 8),
+                  Text('Élément légal : ${corr.elementsConstitutifs.elementLegal}'),
+                  ...corr.elementsConstitutifs.elementMateriel.map((e) => Text('- $e')),
+                  Text('Élément moral : ${corr.elementsConstitutifs.elementMoral}'),
+                  const SizedBox(height: 8),
+                  if (corr.elementsDePreuve.materielles.isNotEmpty) ...[
+                    const Text('Preuves matérielles :'),
+                    ...corr.elementsDePreuve.materielles.map((e) => Text('- $e')),
+                    const SizedBox(height: 4),
+                  ],
+                  if (corr.elementsDePreuve.medicales.isNotEmpty) ...[
+                    const Text('Preuves médicales :'),
+                    ...corr.elementsDePreuve.medicales.map((e) => Text('- $e')),
+                    const SizedBox(height: 4),
+                  ],
+                  if (corr.elementsDePreuve.morales.isNotEmpty) ...[
+                    const Text('Preuves morales :'),
+                    ...corr.elementsDePreuve.morales.map((e) => Text('- $e')),
+                  ],
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/recherche/recherche_infraction_detail_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_detail_screen.dart
@@ -43,7 +43,8 @@ class RechercheInfractionDetailScreen extends StatelessWidget {
                     ),
                   );
                 },
-                child: const Text('Trouve la qualification pour tous les infractions'),
+                child:
+                    const Text('Trouve la qualification pour toutes les infractions'),
               ),
             ),
           ],

--- a/lib/screens/recherche/recherche_infraction_list_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_list_screen.dart
@@ -1,6 +1,4 @@
 import 'dart:convert';
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 import '../../models/exercice_infraction.dart';
@@ -14,9 +12,9 @@ class RechercheInfractionListScreen extends StatefulWidget {
   State<RechercheInfractionListScreen> createState() => _RechercheInfractionListScreenState();
 }
 
-class _RechercheInfractionListScreenState extends State<RechercheInfractionListScreen> {
+class _RechercheInfractionListScreenState
+    extends State<RechercheInfractionListScreen> {
   late Future<List<ExerciceInfraction>> _cases;
-  final _random = Random();
 
   @override
   void initState() {
@@ -34,27 +32,6 @@ class _RechercheInfractionListScreenState extends State<RechercheInfractionListS
         .toList();
   }
 
-  TextStyle _randomStyle() {
-    const fonts = [null, 'serif', 'monospace'];
-    return TextStyle(
-      fontFamily: fonts[_random.nextInt(fonts.length)],
-      fontStyle: _random.nextBool() ? FontStyle.italic : FontStyle.normal,
-      fontWeight: _random.nextBool() ? FontWeight.bold : FontWeight.normal,
-      color: Colors.black87,
-    );
-  }
-
-  Color _randomCardColor() {
-    const colors = [
-      Color(0xFFFFF3E0),
-      Color(0xFFE3F2FD),
-      Color(0xFFE8F5E9),
-      Color(0xFFFCE4EC),
-      Color(0xFFFFF8E1),
-    ];
-    return colors[_random.nextInt(colors.length)];
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -70,16 +47,16 @@ class _RechercheInfractionListScreenState extends State<RechercheInfractionListS
             itemCount: list.length,
             itemBuilder: (context, index) {
               final item = list[index];
-              final style = _randomStyle();
               return Card(
-                color: _randomCardColor(),
                 margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
                 child: ListTile(
-                  title: Text(item.titre, style: style),
+                  title: Text(item.titre),
+                  trailing: const Icon(Icons.chevron_right),
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => RechercheInfractionDetailScreen(caseData: item),
+                        builder: (_) =>
+                            RechercheInfractionDetailScreen(caseData: item),
                       ),
                     );
                   },

--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/exercice_infraction.dart';
 import '../../utils/infraction_suggestions.dart';
+import 'recherche_infraction_result_screen.dart';
 
 class RechercheInfractionQuizScreen extends StatefulWidget {
   final ExerciceInfraction caseData;
@@ -21,50 +22,6 @@ class _RechercheInfractionQuizScreenState
     _intitules = loadInfractionIntitules();
   }
 
-  Future<void> _showResultSummary({
-    required bool success,
-    required int correct,
-    required int incorrect,
-    required int manquantes,
-  }) async {
-    if (!mounted) return;
-    await showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(success ? 'Bravo !' : 'Raté…'),
-        content: Card(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: success
-                    ? [Colors.greenAccent, Colors.green]
-                    : [Colors.redAccent, Colors.orange],
-              ),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text('Correctes : $correct'),
-                Text('Incorrectes : $incorrect'),
-                Text('Manquantes : $manquantes'),
-              ],
-            ),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
-  }
-
   Future<void> _validate() async {
     final expected = widget.caseData.infractionsCiblees
         .map((e) => e.intitule.toLowerCase())
@@ -75,11 +32,18 @@ class _RechercheInfractionQuizScreenState
     final manquantes = expected.difference(provided);
     final success =
         correct.length == expected.length && incorrect.isEmpty && manquantes.isEmpty;
-    await _showResultSummary(
-      success: success,
-      correct: correct.length,
-      incorrect: incorrect.length,
-      manquantes: manquantes.length,
+
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => RechercheInfractionResultScreen(
+          caseData: widget.caseData,
+          correct: correct.length,
+          incorrect: incorrect.length,
+          manquantes: manquantes.length,
+          success: success,
+        ),
+      ),
     );
   }
 

--- a/lib/screens/recherche/recherche_infraction_result_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_result_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import '../../models/exercice_infraction.dart';
+import 'recherche_infraction_correction_screen.dart';
+
+class RechercheInfractionResultScreen extends StatelessWidget {
+  final ExerciceInfraction caseData;
+  final int correct;
+  final int incorrect;
+  final int manquantes;
+  final bool success;
+
+  const RechercheInfractionResultScreen({
+    super.key,
+    required this.caseData,
+    required this.correct,
+    required this.incorrect,
+    required this.manquantes,
+    required this.success,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = success
+        ? [Colors.greenAccent, Colors.green]
+        : [Colors.redAccent, Colors.orange];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Résultat')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(colors: colors),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      success ? 'Bravo !' : 'Raté…',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text('Correctes : $correct'),
+                    Text('Incorrectes : $incorrect'),
+                    Text('Manquantes : $manquantes'),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        RechercheInfractionCorrectionScreen(caseData: caseData),
+                  ),
+                );
+              },
+              child: const Text('Voir la correction'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/quiz_progress_manager_test.dart
+++ b/test/quiz_progress_manager_test.dart
@@ -12,18 +12,18 @@ void main() {
   });
 
   test('enregistrement de reponses et recuperation des stats', () async {
-    await QuizProgressManager.recordQuestion('cadre1', true);
-    await QuizProgressManager.recordQuestion('cadre1', false);
-    await QuizProgressManager.recordQuestion('cadre2', true);
+    await QuizProgressManager.recordQuestion('question1', true);
+    await QuizProgressManager.recordQuestion('question1', false);
+    await QuizProgressManager.recordQuestion('question2', true);
 
     final stats = await QuizProgressManager.getStats();
-    final cadre1 = stats['cadre1'];
-    final cadre2 = stats['cadre2'];
+    final q1 = stats['question1'];
+    final q2 = stats['question2'];
 
-    expect(cadre1?.answered, 2);
-    expect(cadre1?.correct, 1);
-    expect(cadre2?.answered, 1);
-    expect(cadre2?.correct, 1);
+    expect(q1?.answered, 2);
+    expect(q1?.correct, 1);
+    expect(q2?.answered, 1);
+    expect(q2?.correct, 1);
   });
 
   test('increment du compteur global de quiz', () async {


### PR DESCRIPTION
## Summary
- Nettoie le menu d'entraînement pour ne conserver que le Quiz PP, la recherche d'infractions et les statistiques.
- Modernise la recherche d'infractions : titres listés depuis `exercice_infractions.json`, affichage détaillé de chaque scénario, choix des intitulés, page de résultat et page de correction.
- Met à jour les tests pour utiliser des identifiants génériques.

## Testing
- `flutter test` *(échoue : command not found)*
- `dart test` *(échoue : command not found)*
- `apt-get update` *(échoue : repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68931bb07e38832d9c9fc0e8c0a0ce56