### PR TITLE
Corrige la recherche d'infractions insensible aux espaces

### DIFF
--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -69,10 +69,10 @@ class _RechercheInfractionQuizScreenState
               children: [
                 Autocomplete<String>(
                   optionsBuilder: (TextEditingValue textEditingValue) {
-                    if (textEditingValue.text.isEmpty) {
+                    final query = textEditingValue.text.trim().toLowerCase();
+                    if (query.isEmpty) {
                       return const Iterable<String>.empty();
                     }
-                    final query = textEditingValue.text.toLowerCase();
                     return intitules.where((i) =>
                         i.toLowerCase().contains(query) && !_selected.contains(i));
                   },

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -45,12 +45,17 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   void _onSearch(String query) {
-    final lower = query.toLowerCase();
+    final lower = query.trim().toLowerCase();
     setState(() {
-      _filteredInfractions = _allInfractions
-          .where((inf) => (inf.type ?? '').toLowerCase().contains(lower) ||
-              (inf.definition ?? '').toLowerCase().contains(lower))
-          .toList();
+      if (lower.isEmpty) {
+        _filteredInfractions = _allInfractions;
+      } else {
+        _filteredInfractions = _allInfractions
+            .where((inf) =>
+                (inf.type ?? '').toLowerCase().contains(lower) ||
+                (inf.definition ?? '').toLowerCase().contains(lower))
+            .toList();
+      }
     });
   }
 


### PR DESCRIPTION
## Résumé
- Normalize les requêtes de recherche pour ignorer les espaces superflus
- Améliore les suggestions d'infractions dans "Trouver les infractions"

## Tests
- `flutter test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68932564b438832d959f108362ddb72f