### PR TITLE
Ajout de l'écran Cadres d'enquête

### DIFF
--- a/lib/screens/cadre_enquete_list_screen.dart
+++ b/lib/screens/cadre_enquete_list_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class CadreEnqueteListScreen extends StatelessWidget {
+  const CadreEnqueteListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cadres = const [
+      'Cadre 1',
+      'Cadre 2',
+      'Cadre 3',
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cadres d\'enquête'),
+      ),
+      body: ListView.builder(
+        itemCount: cadres.length,
+        itemBuilder: (context, index) => ListTile(
+          title: Text(cadres[index]),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/procedure_penale_menu_screen.dart
+++ b/lib/screens/procedure_penale_menu_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import '../widgets/adaptive_appbar_title.dart';
 import '../widgets/ad_banner.dart';
+import '../widgets/modern_gradient_button.dart';
+
+import 'cadre_enquete_list_screen.dart';
 
 
 class ProcedurePenaleMenuScreen extends StatelessWidget {
@@ -36,6 +39,23 @@ class ProcedurePenaleMenuScreen extends StatelessWidget {
                         child: Image.asset(
                           'assets/images/logocreme.png',
                           width: 260,
+                        ),
+                      ),
+                      FractionallySizedBox(
+                        widthFactor: 0.85,
+                        child: ModernGradientButton(
+                          icon: Icons.search,
+                          label: 'Cadres d\'enquête',
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              PageRouteBuilder(
+                                pageBuilder: (_, animation, __) => FadeTransition(
+                                  opacity: animation,
+                                  child: const CadreEnqueteListScreen(),
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ],


### PR DESCRIPTION
## Résumé
- ajout d'un bouton "Cadres d'enquête" dans le menu Procédure pénale
- navigation vers un nouvel écran listant quelques cadres d'enquête

## Tests
- `flutter analyze` *(échoué : commande introuvable)*
- `flutter test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68934bbc2f00832da90a9039f64f46b2