### PR TITLE
Ajoute navigation vers l'écran de détail des cadres

### DIFF
--- a/lib/screens/cadre_enquete_list_screen.dart
+++ b/lib/screens/cadre_enquete_list_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/cadre.dart';
+import 'cadre_detail_screen.dart';
 
 class CadreEnqueteListScreen extends StatefulWidget {
   const CadreEnqueteListScreen({super.key});
@@ -56,6 +57,16 @@ class _CadreEnqueteListScreenState extends State<CadreEnqueteListScreen> {
                       return ListTile(
                         title: Text(cadre.title),
                         subtitle: Text(cadre.description),
+                        onTap: () {
+                          Navigator.of(context).push(
+                            PageRouteBuilder(
+                              pageBuilder: (_, animation, __) => FadeTransition(
+                                opacity: animation,
+                                child: CadreDetailScreen(cadre: cadre),
+                              ),
+                            ),
+                          );
+                        },
                       );
                     },
                   ),


### PR DESCRIPTION
## Résumé
- importe `cadre_detail_screen.dart` pour permettre l'accès aux détails d'un cadre
- ajoute une navigation avec `FadeTransition` vers `CadreDetailScreen` lors du tap sur un item

## Tests
- `flutter test` *(échoué : commande flutter introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689353f50308832da9155d373b31773a