### PR TITLE
feat: make Cadre constructor const

### DIFF
--- a/lib/models/cadre.dart
+++ b/lib/models/cadre.dart
@@ -2,7 +2,7 @@ class Cadre {
   final String title;
   final String description;
 
-  Cadre({required this.title, required this.description});
+  const Cadre({required this.title, required this.description});
 
   factory Cadre.fromJson(Map<String, dynamic> json) => Cadre(
         title: json['title'] ?? '',


### PR DESCRIPTION
## Summary
- mark Cadre constructor as const for immutability
- ensure Cadre can be created from JSON via `fromJson`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689353f922e0832da812618ef74cf561