### PR TITLE
Utiliser exercice_infractions.json pour les suggestions et la recherche

### DIFF
--- a/lib/screens/recherche/recherche_infraction_list_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_list_screen.dart
@@ -25,7 +25,7 @@ class _RechercheInfractionListScreenState extends State<RechercheInfractionListS
   }
 
   Future<List<RechercheInfraction>> _loadCases() async {
-    final data = await loadJsonWithComments('assets/data/recherche_infractions.json');
+    final data = await loadJsonWithComments('assets/data/exercice_infractions.json');
     final List<dynamic> raw = json.decode(data) as List<dynamic>;
     return raw
         .whereType<Map<String, dynamic>>()

--- a/lib/utils/infraction_suggestions.dart
+++ b/lib/utils/infraction_suggestions.dart
@@ -6,7 +6,7 @@ import 'json_loader.dart';
 /// l'application.
 ///
 /// Les suggestions sont extraites des fichiers `fiches.json` et
-/// `recherche_infractions.json` afin de couvrir intégralement les infractions
+/// `exercice_infractions.json` afin de couvrir intégralement les infractions
 /// présentes dans les histoires.
 Future<List<String>> loadInfractionSuggestions() async {
   final set = <String>{};
@@ -26,7 +26,7 @@ Future<List<String>> loadInfractionSuggestions() async {
 
   // Suggestions provenant des scénarios de recherche d'infractions
   final rechercheData =
-      await loadJsonWithComments('assets/data/recherche_infractions.json');
+      await loadJsonWithComments('assets/data/exercice_infractions.json');
   final List<dynamic> rechercheRaw = json.decode(rechercheData) as List<dynamic>;
   for (final item in rechercheRaw) {
     final corrections = (item as Map)['correction'] as List? ?? [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,7 @@ flutter:
     - assets/data/loader_test.json
     - assets/data/quiz_cadre_enquete.json
     - assets/data/quiz_pp.json
-    - assets/data/recherche_infractions.json
+    - assets/data/exercice_infractions.json
     - assets/images/
   #   - images/a_dot_ham.jpeg
 

--- a/test/exercice_infractions_parsing_test.dart
+++ b/test/exercice_infractions_parsing_test.dart
@@ -6,8 +6,8 @@ import 'package:droitpenalspecial/models/recherche_infraction.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('chargement des cas depuis recherche_infractions.json', () async {
-    final data = await rootBundle.loadString('assets/data/recherche_infractions.json');
+  test('chargement des cas depuis exercice_infractions.json', () async {
+    final data = await rootBundle.loadString('assets/data/exercice_infractions.json');
     final List<dynamic> list = json.decode(data) as List<dynamic>;
     expect(() => list.map((e) => RechercheInfraction.fromJson(e)).toList(), returnsNormally);
   });


### PR DESCRIPTION
## Résumé
- charge les suggestions d'infractions à partir de `exercice_infractions.json`
- lit les cas de recherche depuis `exercice_infractions.json`
- ajoute l'asset `assets/data/exercice_infractions.json` dans le `pubspec`
- met à jour le test de parsing pour utiliser `exercice_infractions.json`

## Tests
- `flutter test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893656b775c832d85c7298eaf0ce95b