### PR TITLE
Ajout des infractions ciblées aux suggestions et à la validation

### DIFF
--- a/lib/models/recherche_infraction.dart
+++ b/lib/models/recherche_infraction.dart
@@ -1,26 +1,40 @@
 class RechercheInfraction {
   final String titre;
   final String histoire;
-  final List<String> infractions;
+  final List<String> intitulesAttendus;
 
   RechercheInfraction({
     required this.titre,
     required this.histoire,
-    required this.infractions,
+    required this.intitulesAttendus,
   });
 
   factory RechercheInfraction.fromJson(Map<String, dynamic> json) {
-    final corrections = json['correction'] as List? ?? [];
-    final infractions = corrections
-        .map((e) => ((e as Map)['infraction'] as Map)['qualification'] as String?)
+    // Priorité aux intitulés ciblés si présents.
+    final ciblees = (json['infractions_ciblees'] as List? ?? [])
+        .map((e) => (e as Map)['intitule'] as String?)
         .whereType<String>()
         .map((s) => s.trim())
         .where((s) => s.isNotEmpty)
         .toList();
+
+    List<String> attendus = ciblees;
+    if (attendus.isEmpty) {
+      // Compatibilité avec l'ancien format basé sur `correction`.
+      final corrections = json['correction'] as List? ?? [];
+      attendus = corrections
+          .map((e) =>
+              ((e as Map)['infraction'] as Map)['qualification'] as String?)
+          .whereType<String>()
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList();
+    }
+
     return RechercheInfraction(
       titre: json['titre'] ?? '',
-      histoire: json['histoire'] ?? '',
-      infractions: infractions,
+      histoire: json['histoire'] ?? json['histoire_detaillee'] ?? '',
+      intitulesAttendus: attendus,
     );
   }
 }

--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -79,7 +79,8 @@ class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizS
     );
   }
   Future<void> _validate() async {
-    final expected = widget.caseData.infractions.map((e) => e.toLowerCase()).toSet();
+    final expected =
+        widget.caseData.intitulesAttendus.map((e) => e.toLowerCase()).toSet();
     final provided = _controllers
         .whereType<TextEditingController>()
         .map((c) => c.text.trim().toLowerCase())

--- a/lib/utils/infraction_suggestions.dart
+++ b/lib/utils/infraction_suggestions.dart
@@ -5,9 +5,10 @@ import 'json_loader.dart';
 /// Charge et renvoie la liste des intitulés d'infractions disponibles dans
 /// l'application.
 ///
-/// Les suggestions sont extraites des fichiers `fiches.json` et
-/// `recherche_infractions.json` afin de couvrir intégralement les infractions
-/// présentes dans les histoires.
+/// Les suggestions sont extraites des fichiers `fiches.json`,
+/// `recherche_infractions.json` et `exercice_infractions.json` afin de couvrir
+/// intégralement les infractions présentes dans les histoires et les
+/// exercices.
 Future<List<String>> loadInfractionSuggestions() async {
   final set = <String>{};
 
@@ -35,6 +36,21 @@ Future<List<String>> loadInfractionSuggestions() async {
       final qual = inf['qualification'];
       if (qual is String && qual.trim().isNotEmpty) {
         set.add(qual);
+      }
+    }
+  }
+
+  // Suggestions provenant des exercices d'infractions
+  final exercicesData =
+      await loadJsonWithComments('assets/data/exercice_infractions.json');
+  final List<dynamic> exercicesRaw =
+      json.decode(exercicesData) as List<dynamic>;
+  for (final item in exercicesRaw) {
+    final ciblees = (item as Map)['infractions_ciblees'] as List? ?? [];
+    for (final ciblee in ciblees) {
+      final intitule = (ciblee as Map)['intitule'];
+      if (intitule is String && intitule.trim().isNotEmpty) {
+        set.add(intitule);
       }
     }
   }

--- a/test/infraction_suggestions_test.dart
+++ b/test/infraction_suggestions_test.dart
@@ -8,6 +8,8 @@ void main() {
     final suggestions = await loadInfractionSuggestions();
     expect(suggestions, contains('Vol'));
     expect(suggestions, contains('Abus de confiance'));
+    expect(suggestions,
+        contains("Privation d'aliments ou de soins à un mineur de 15 ans"));
     expect(suggestions.isNotEmpty, true);
   });
 }


### PR DESCRIPTION
## Résumé
- intègre les intitulés d`exercice_infractions.json` dans les suggestions
- stocke les infractions ciblées dans le modèle RechercheInfraction
- valide les réponses du quiz sur la base de ces intitulés

## Tests
- `flutter test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68936885b88c832db4961bd37474fcb0