### PR TITLE
Ajout de l’écran de correction des infractions

### DIFF
--- a/lib/screens/recherche/recherche_infraction_correction_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_correction_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import '../../models/exercice_infraction.dart';
+import '../theme_screen.dart';
+
+class RechercheInfractionCorrectionScreen extends StatelessWidget {
+  final ExerciceInfraction caseData;
+  const RechercheInfractionCorrectionScreen({super.key, required this.caseData});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Correction')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          for (final corr in caseData.correction) _buildCard(context, corr),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const ThemeScreen()),
+                );
+              },
+              child: const Text('Retour aux thèmes'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard(BuildContext context, Map<String, dynamic> data) {
+    final numero = data['infraction_numero'];
+    final personne = data['personne_concernee'];
+    final qualification = data['infraction']?['qualification'];
+    final articles = data['elements_constitutifs']?['element_legal'];
+    final elementMateriel = data['elements_constitutifs']?['element_materiel'];
+    final elementMoral = data['elements_constitutifs']?['element_moral'];
+    final preuves = data['elements_de_preuve'] ?? <String, dynamic>{};
+    final preuvesMaterielles = (preuves['materielles'] as List?)?.whereType<String>() ?? [];
+    final preuvesMedicales = (preuves['medicales'] as List?)?.whereType<String>() ?? [];
+    final preuvesMorales = (preuves['morales'] as List?)?.whereType<String>() ?? [];
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Infraction n°$numero', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text('Personne concernée : $personne'),
+            const SizedBox(height: 8),
+            if (qualification != null) ...[
+              Text('Qualification : $qualification'),
+              const SizedBox(height: 8),
+            ],
+            if (articles != null) ...[
+              Text('Articles : $articles'),
+              const SizedBox(height: 8),
+            ],
+            if (elementMateriel != null || elementMoral != null) ...[
+              const Text('Éléments constitutifs :'),
+              if (elementMateriel is List)
+                for (final e in elementMateriel) Text('- $e')
+              else if (elementMateriel != null)
+                Text('- $elementMateriel'),
+              if (elementMoral != null) Text('- $elementMoral'),
+              const SizedBox(height: 8),
+            ],
+            if (preuvesMaterielles.isNotEmpty || preuvesMedicales.isNotEmpty || preuvesMorales.isNotEmpty) ...[
+              const Text('Éléments de preuve :'),
+              if (preuvesMaterielles.isNotEmpty) ...[
+                const Text('Matérielles :'),
+                for (final p in preuvesMaterielles) Text('- $p'),
+              ],
+              if (preuvesMedicales.isNotEmpty) ...[
+                const Text('Médicales :'),
+                for (final p in preuvesMedicales) Text('- $p'),
+              ],
+              if (preuvesMorales.isNotEmpty) ...[
+                const Text('Morales :'),
+                for (final p in preuvesMorales) Text('- $p'),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/exercice_infraction.dart';
 import '../../utils/infraction_suggestions.dart';
+import 'recherche_infraction_correction_screen.dart';
 
 class RechercheInfractionQuizScreen extends StatefulWidget {
   final ExerciceInfraction caseData;
@@ -94,6 +95,12 @@ class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizS
       correct: correct.length,
       incorrect: incorrect.length,
       manquantes: manquantes.length,
+    );
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => RechercheInfractionCorrectionScreen(caseData: widget.caseData),
+      ),
     );
   }
 


### PR DESCRIPTION
## Résumé
- Crée un écran affichant la correction détaillée des infractions et un retour vers la liste des thèmes.
- Dirige l’utilisateur vers cet écran après la validation du quiz.

## Tests
- `flutter analyze` *(échoue : command not found)*
- `flutter test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689370f63190832da249d3d480074a6f