### PR TITLE
Affiche un champ dès l'ouverture du quiz d'infractions

### DIFF
--- a/lib/screens/recherche/recherche_infraction_quiz_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_quiz_screen.dart
@@ -19,6 +19,7 @@ class _RechercheInfractionQuizScreenState extends State<RechercheInfractionQuizS
   void initState() {
     super.initState();
     _suggestions = loadInfractionSuggestions();
+    _addField();
   }
 
   @override

--- a/test/recherche_infraction_quiz_screen_test.dart
+++ b/test/recherche_infraction_quiz_screen_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:droitpenalspecial/models/exercice_infraction.dart';
+import 'package:droitpenalspecial/screens/recherche/recherche_infraction_quiz_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('affiche un champ vide au démarrage', (tester) async {
+    final caseData = ExerciceInfraction(
+      titre: '',
+      contextualisation: '',
+      histoireDetaillee: '',
+      infractionsCiblees: const [],
+      correction: const [],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RechercheInfractionQuizScreen(caseData: caseData),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsOneWidget);
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.controller?.text ?? '', isEmpty);
+  });
+}


### PR DESCRIPTION
## Résumé
- appelle `_addField()` lors de l'initialisation pour créer un champ de saisie dès l'ouverture
- ajoute un test widget vérifiant la présence d'un champ vide au démarrage

## Tests
- `flutter analyze` *(échoue : command not found)*
- `flutter test` *(échoue : command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893739d6934832dadc7ea3777084732