### PR TITLE
Mélange aléatoire des propositions dans le quiz de procédure pénale

### DIFF
--- a/lib/screens/quiz_pp_screen.dart
+++ b/lib/screens/quiz_pp_screen.dart
@@ -37,6 +37,9 @@ class _QuizPPScreenState extends State<QuizPPScreen> {
           .map((e) => QuizPPQuestion.fromJson(e.cast<String, dynamic>()))
           .toList()
         ..shuffle();
+      for (final question in questions) {
+        question.propositions.shuffle();
+      }
       _questions = questions.length > 12 ? questions.take(12).toList() : questions;
       _loading = false;
     });


### PR DESCRIPTION
## Résumé
- Mélange chaque liste de propositions lors du chargement des questions du quiz PP.

## Tests
- `flutter test` *(échec : commande introuvable)*
- `dart test` *(échec : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_689603f20f34832dbed23b3569e7c276