### PR TITLE
Ajoute bannière publicitaire dans l'écran de détail de recherche

### DIFF
--- a/lib/screens/recherche/recherche_infraction_detail_screen.dart
+++ b/lib/screens/recherche/recherche_infraction_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'dart:ui';
 
 import '../../models/exercice_infraction.dart';
+import '../../widgets/ad_banner.dart';
 import 'recherche_infraction_quiz_screen.dart';
 
 class RechercheInfractionDetailScreen extends StatefulWidget {
@@ -152,6 +153,8 @@ class _RechercheInfractionDetailScreenState extends State<RechercheInfractionDet
                 child: const Text('Trouve  les infractions'),
               ),
             ),
+            const SizedBox(height: 8),
+            const AdBanner(),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- affiche une bannière publicitaire sous le bouton du quiz d'infractions

## Testing
- `flutter test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68960cade124832d985eec333c534d08