### PR TITLE
Masquer l'acte dans le quiz DPS

### DIFF
--- a/lib/screens/quiz_dps_screen.dart
+++ b/lib/screens/quiz_dps_screen.dart
@@ -104,25 +104,25 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
                 ),
               ),
               const SizedBox(height: 8),
-              Card(
-                elevation: 4,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                color: Colors.white24,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                  child: Text(
-                    question.acte,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-              ),
+              // Card(
+              //   elevation: 4,
+              //   shape: RoundedRectangleBorder(
+              //     borderRadius: BorderRadius.circular(8),
+              //   ),
+              //   color: Colors.white24,
+              //   child: Padding(
+              //     padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+              //     child: Text(
+              //       question.acte,
+              //       textAlign: TextAlign.center,
+              //       style: const TextStyle(
+              //         fontSize: 16,
+              //         color: Colors.white,
+              //         fontWeight: FontWeight.w600,
+              //       ),
+              //     ),
+              //   ),
+              // ),
             ],
           ),
         ),


### PR DESCRIPTION
## Résumé
- Commentaire du bloc `Card` dans `quiz_dps_screen.dart` pour ne plus afficher l'acte, ne laissant que le thème et les options de réponse.

## Test
- `dart analyze` *(échec : commande introuvable)*
- `flutter test` *(échec : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_689712047274832d813c4eea97fbb965