### PR TITLE
Ajoute theme et sourceCategorie aux questions du quiz DPS

### DIFF
--- a/lib/models/quiz_pp_question.dart
+++ b/lib/models/quiz_pp_question.dart
@@ -3,13 +3,23 @@ import 'quiz_question.dart';
 class QuizPPQuestion {
   final String cadre;
   final String acte;
+  final String theme;
+  final String sourceCategorie;
   final List<QuizOption> propositions;
 
-  QuizPPQuestion({required this.cadre, required this.acte, required this.propositions});
+  QuizPPQuestion({
+    required this.cadre,
+    required this.acte,
+    required this.propositions,
+    this.theme = '',
+    this.sourceCategorie = '',
+  });
 
   factory QuizPPQuestion.fromJson(Map<String, dynamic> json) => QuizPPQuestion(
         cadre: json['cadre'] ?? '',
         acte: json['acte'] ?? '',
+        theme: json['theme'] ?? '',
+        sourceCategorie: json['_source_categorie'] ?? '',
         propositions: (json['propositions'] as List? ?? [])
             .whereType<Map>()
             .map((e) => QuizOption.fromJson(e.cast<String, dynamic>()))

--- a/lib/screens/quiz_dps_screen.dart
+++ b/lib/screens/quiz_dps_screen.dart
@@ -46,10 +46,15 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
                   isCorrect: i == correctIndex,
                 ),
             ];
+            final sourceCategorie =
+                item['_source_categorie'] as String? ?? '';
+            final itemTheme = item['theme'] as String? ?? '';
             questions.add(
               QuizPPQuestion(
                 cadre: theme,
                 acte: item['question'] as String? ?? '',
+                sourceCategorie: sourceCategorie,
+                theme: itemTheme,
                 propositions: propositions,
               ),
             );
@@ -95,7 +100,7 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text(
-                question.cadre,
+                question.sourceCategorie,
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   fontSize: 18,
@@ -104,25 +109,15 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
                 ),
               ),
               const SizedBox(height: 8),
-              // Card(
-              //   elevation: 4,
-              //   shape: RoundedRectangleBorder(
-              //     borderRadius: BorderRadius.circular(8),
-              //   ),
-              //   color: Colors.white24,
-              //   child: Padding(
-              //     padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-              //     child: Text(
-              //       question.acte,
-              //       textAlign: TextAlign.center,
-              //       style: const TextStyle(
-              //         fontSize: 16,
-              //         color: Colors.white,
-              //         fontWeight: FontWeight.w600,
-              //       ),
-              //     ),
-              //   ),
-              // ),
+              Text(
+                question.acte,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Résumé
- étend le modèle `QuizPPQuestion` avec `theme` et `sourceCategorie` chargés depuis le JSON
- charge les nouveaux champs dans l’écran DPS et affiche la catégorie source puis la question

## Tests
- `flutter test` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*
- tentative `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_689755a0d638832d8afce218e7d4b5b8