### PR TITLE
Enregistrer les statistiques de quiz par thème

### DIFF
--- a/lib/models/quiz_pp_question.dart
+++ b/lib/models/quiz_pp_question.dart
@@ -1,13 +1,20 @@
 import 'quiz_question.dart';
 
 class QuizPPQuestion {
+  final String theme;
   final String cadre;
   final String acte;
   final List<QuizOption> propositions;
 
-  QuizPPQuestion({required this.cadre, required this.acte, required this.propositions});
+  QuizPPQuestion({
+    required this.theme,
+    required this.cadre,
+    required this.acte,
+    required this.propositions,
+  });
 
   factory QuizPPQuestion.fromJson(Map<String, dynamic> json) => QuizPPQuestion(
+        theme: json['theme'] ?? json['cadre'] ?? '',
         cadre: json['cadre'] ?? '',
         acte: json['acte'] ?? '',
         propositions: (json['propositions'] as List? ?? [])

--- a/lib/screens/quiz_dps_screen.dart
+++ b/lib/screens/quiz_dps_screen.dart
@@ -48,6 +48,7 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
             ];
             questions.add(
               QuizPPQuestion(
+                theme: theme,
                 cadre: theme,
                 acte: item['question'] as String? ?? '',
                 propositions: propositions,
@@ -377,7 +378,7 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
     if (correct) {
       _score++;
     }
-    await QuizProgressManager.recordQuestion('global', correct);
+    await QuizProgressManager.recordQuestion(question.theme, correct);
 
     // Build correctOptions and selectedOptions lists
     final correctOptions = question.propositions

--- a/lib/screens/quiz_pp_screen.dart
+++ b/lib/screens/quiz_pp_screen.dart
@@ -355,7 +355,7 @@ class _QuizPPScreenState extends State<QuizPPScreen> {
     if (correct) {
       _score++;
     }
-    await QuizProgressManager.recordQuestion(question.cadre, correct);
+    await QuizProgressManager.recordQuestion(question.theme, correct);
 
     // Build correctOptions and selectedOptions lists
     final correctOptions = question.propositions


### PR DESCRIPTION
## Résumé
- Ajout d'un champ `theme` aux questions de procédure pénale pour tracer les réponses par thème.
- Les écrans de quiz DPS et PP enregistrent désormais les statistiques en utilisant le thème de la question.

## Tests
- `dart format lib/models/quiz_pp_question.dart lib/screens/quiz_dps_screen.dart lib/screens/quiz_pp_screen.dart` *(échoue : commande introuvable)*
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689755ab11a8832d9a6e5e12aaa1a8d4