### PR TITLE
Supprime les doublons du champ theme dans QuizPPQuestion

### DIFF
--- a/lib/models/quiz_pp_question.dart
+++ b/lib/models/quiz_pp_question.dart
@@ -4,12 +4,10 @@ class QuizPPQuestion {
   final String theme;
   final String cadre;
   final String acte;
-  final String theme;
   final String sourceCategorie;
   final List<QuizOption> propositions;
 
   QuizPPQuestion({
-
     required this.cadre,
     required this.acte,
     required this.propositions,
@@ -18,15 +16,14 @@ class QuizPPQuestion {
   });
 
   factory QuizPPQuestion.fromJson(Map<String, dynamic> json) => QuizPPQuestion(
-        theme: json['theme'] ?? json['cadre'] ?? '',
         cadre: json['cadre'] ?? '',
         acte: json['acte'] ?? '',
-        theme: json['theme'] ?? '',
-        sourceCategorie: json['_source_categorie'] ?? '',
         propositions: (json['propositions'] as List? ?? [])
             .whereType<Map>()
             .map((e) => QuizOption.fromJson(e.cast<String, dynamic>()))
             .toList(),
+        theme: json['theme'] ?? json['cadre'] ?? '',
+        sourceCategorie: json['_source_categorie'] ?? '',
       );
 
   Set<int> get correctIndices => {

--- a/lib/screens/quiz_dps_screen.dart
+++ b/lib/screens/quiz_dps_screen.dart
@@ -48,10 +48,10 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
             ];
             final sourceCategorie =
                 item['_source_categorie'] as String? ?? '';
-            final itemTheme = item['theme'] as String? ?? '';
+            final rawTheme = item['theme'] as String? ?? '';
+            final itemTheme = rawTheme.isNotEmpty ? rawTheme : theme;
             questions.add(
               QuizPPQuestion(
-                theme: theme,
                 cadre: theme,
                 acte: item['question'] as String? ?? '',
                 sourceCategorie: sourceCategorie,


### PR DESCRIPTION
## Résumé
- élimination de la double déclaration `theme` dans `QuizPPQuestion` et mise à jour de la fabrique JSON
- suppression de l'argument `theme` dupliqué lors de la création des questions DPS

## Test
- `flutter test` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68975795226c832d8c81a5801b5ba32c