### PR TITLE
Séparation des statistiques PP et DPS

### DIFF
--- a/lib/screens/quiz_cadre_screen.dart
+++ b/lib/screens/quiz_cadre_screen.dart
@@ -131,7 +131,11 @@ class _QuizCadreScreenState extends State<QuizCadreScreen> {
     if (correct) {
       _score++;
     }
-    await QuizProgressManager.recordQuestion(question.cadre, correct);
+    await QuizProgressManager.recordQuestion(
+      question.cadre,
+      correct,
+      quiz: QuizType.pp,
+    );
 
     setState(() {
       _feedbackColor = correct ? Colors.green : Colors.red;

--- a/lib/screens/quiz_dps_screen.dart
+++ b/lib/screens/quiz_dps_screen.dart
@@ -373,7 +373,11 @@ class _QuizDPSScreenState extends State<QuizDPSScreen> {
     if (correct) {
       _score++;
     }
-    await QuizProgressManager.recordQuestion(question.theme, correct);
+    await QuizProgressManager.recordQuestion(
+      question.theme,
+      correct,
+      quiz: QuizType.dps,
+    );
 
     // Build correctOptions and selectedOptions lists
     final correctOptions = question.propositions

--- a/lib/screens/quiz_pp_screen.dart
+++ b/lib/screens/quiz_pp_screen.dart
@@ -355,7 +355,11 @@ class _QuizPPScreenState extends State<QuizPPScreen> {
     if (correct) {
       _score++;
     }
-    await QuizProgressManager.recordQuestion(question.theme, correct);
+    await QuizProgressManager.recordQuestion(
+      question.cadre,
+      correct,
+      quiz: QuizType.pp,
+    );
 
     // Build correctOptions and selectedOptions lists
     final correctOptions = question.propositions

--- a/test/quiz_progress_manager_test.dart
+++ b/test/quiz_progress_manager_test.dart
@@ -12,18 +12,21 @@ void main() {
   });
 
   test('enregistrement de reponses et recuperation des stats', () async {
-    await QuizProgressManager.recordQuestion('cadre1', true);
-    await QuizProgressManager.recordQuestion('cadre1', false);
-    await QuizProgressManager.recordQuestion('cadre2', true);
+    await QuizProgressManager.recordQuestion('cadre1', true,
+        quiz: QuizType.pp);
+    await QuizProgressManager.recordQuestion('cadre1', false,
+        quiz: QuizType.pp);
+    await QuizProgressManager.recordQuestion('theme1', true,
+        quiz: QuizType.dps);
 
     final stats = await QuizProgressManager.getStats();
-    final cadre1 = stats['cadre1'];
-    final cadre2 = stats['cadre2'];
+    final cadre1 = stats[QuizType.pp]?['cadre1'];
+    final theme1 = stats[QuizType.dps]?['theme1'];
 
     expect(cadre1?.answered, 2);
     expect(cadre1?.correct, 1);
-    expect(cadre2?.answered, 1);
-    expect(cadre2?.correct, 1);
+    expect(theme1?.answered, 1);
+    expect(theme1?.correct, 1);
   });
 
   test('increment du compteur global de quiz', () async {


### PR DESCRIPTION
## Summary
- Sépare les statistiques des quiz PP et DPS via une nouvelle structure de stockage
- Affiche deux volets de statistiques avec GradientExpansionTile pour PP et DPS
- Maintient la réinitialisation complète des données

## Testing
- `flutter test` *(échec : commande introuvable)*
- `dart test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689786a6c64c832d955f24d149f9ba1c