### PR TITLE
Affiche par défaut les volets PP et DPS dans les statistiques

### DIFF
--- a/lib/screens/quiz_stats_screen.dart
+++ b/lib/screens/quiz_stats_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../utils/quiz_progress_manager.dart';
 import '../widgets/adaptive_appbar_title.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class QuizStatsScreen extends StatefulWidget {
   const QuizStatsScreen({super.key});
@@ -14,11 +15,14 @@ class _QuizStatsScreenState extends State<QuizStatsScreen> {
   Map<String, QuizStats> _stats = {};
   int _quizCount = 0;
   bool _loading = true;
+  bool _ppExpanded = true;
+  bool _dpsExpanded = true;
 
   @override
   void initState() {
     super.initState();
     _load();
+    _loadExpansionState();
   }
 
   Future<void> _load() async {
@@ -54,6 +58,19 @@ class _QuizStatsScreenState extends State<QuizStatsScreen> {
       await QuizProgressManager.reset();
       await _load();
     }
+  }
+
+  Future<void> _loadExpansionState() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _ppExpanded = prefs.getBool('stats_pp_expanded') ?? true;
+      _dpsExpanded = prefs.getBool('stats_dps_expanded') ?? true;
+    });
+  }
+
+  Future<void> _saveExpansionState(String key, bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(key, value);
   }
 
   @override
@@ -97,6 +114,15 @@ class _QuizStatsScreenState extends State<QuizStatsScreen> {
         : percent >= 0.5
             ? [Colors.amber.shade400, Colors.amber.shade200]
             : [Colors.red.shade400, Colors.red.shade200];
+
+    final ppEntries = _stats.entries
+        .where((e) => _isPP(e.key))
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    final dpsEntries = _stats.entries
+        .where((e) => !_isPP(e.key))
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
 
     return Container(
       decoration: BoxDecoration(
@@ -216,6 +242,54 @@ class _QuizStatsScreenState extends State<QuizStatsScreen> {
               ),
             ),
           ),
+          if (ppEntries.isNotEmpty)
+            _buildExpansion(
+              'Procédure pénale',
+              ppEntries,
+              _ppExpanded,
+              (v) {
+                setState(() => _ppExpanded = v);
+                _saveExpansionState('stats_pp_expanded', v);
+              },
+            ),
+          if (dpsEntries.isNotEmpty)
+            _buildExpansion(
+              'Droit pénal spécial',
+              dpsEntries,
+              _dpsExpanded,
+              (v) {
+                setState(() => _dpsExpanded = v);
+                _saveExpansionState('stats_dps_expanded', v);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  bool _isPP(String key) => key.toUpperCase() == key;
+
+  Widget _buildExpansion(
+    String title,
+    List<MapEntry<String, QuizStats>> entries,
+    bool expanded,
+    ValueChanged<bool> onExpansionChanged,
+  ) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      child: ExpansionTile(
+        title: Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        initiallyExpanded: expanded,
+        onExpansionChanged: onExpansionChanged,
+        children: [
+          for (final e in entries)
+            ListTile(
+              title: Text(e.key),
+              trailing: Text('${e.value.correct} / ${e.value.answered}'),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
## Résumé
- Affiche les statistiques de procédure pénale et de droit pénal spécial dans des sections repliables ouvertes par défaut
- Mémorise l'état d'ouverture des volets avec SharedPreferences pour retrouver le même affichage au retour

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689786cc8e58832d95c3825fb249fa5b